### PR TITLE
✨ feat(lecture): 강의 사용자 추천/북마크 시리얼라이저, mock API 뷰, urls 추가

### DIFF
--- a/apps/lecture/serializers/bookmark_serializers.py
+++ b/apps/lecture/serializers/bookmark_serializers.py
@@ -1,0 +1,78 @@
+from typing import Any, Dict, List
+
+from rest_framework import serializers
+
+from apps.lecture.models import LectureBookmark
+
+
+class LectureBookmarkSerializer(serializers.ModelSerializer[LectureBookmark]):
+    """LectureBookmark 모델과 연동된 북마크 용 강의 정보 직렬화하는 Serializer"""
+
+    # 강의 필드들을 lecture 외래키를 통해 참조하여 읽기 전용으로 노출
+    id = serializers.IntegerField(source="lecture.id", read_only=True)
+    uuid = serializers.UUIDField(source="lecture.uuid", read_only=True)
+    title = serializers.CharField(source="lecture.title", read_only=True)
+    instructor = serializers.CharField(source="lecture.instructor", read_only=True)
+    thumbnail_img_url = serializers.CharField(source="lecture.thumbnail_img_url", read_only=True)
+    difficulty = serializers.CharField(source="lecture.difficulty", read_only=True)
+    original_price = serializers.IntegerField(source="lecture.original_price", read_only=True)
+    discount_price = serializers.IntegerField(source="lecture.discount_price", read_only=True)
+    platform = serializers.CharField(source="lecture.platform", read_only=True)
+    average_rating = serializers.DecimalField(
+        source="lecture.average_rating", max_digits=3, decimal_places=2, read_only=True
+    )
+    duration = serializers.SerializerMethodField()
+    url_link = serializers.URLField(source="lecture.url_link", read_only=True)
+    description = serializers.CharField(source="lecture.description", read_only=True)
+    categories = serializers.SerializerMethodField()
+    reviews = serializers.SerializerMethodField()
+    bookmarked_at = serializers.DateTimeField(source="created_at", read_only=True)
+
+    class Meta:
+        model = LectureBookmark
+        fields = [
+            "id",
+            "uuid",
+            "title",
+            "instructor",
+            "thumbnail_img_url",
+            "categories",
+            "difficulty",
+            "original_price",
+            "discount_price",
+            "platform",
+            "average_rating",
+            "duration",
+            "url_link",
+            "description",
+            "reviews",
+            "bookmarked_at",
+        ]
+
+    def get_categories(self, obj: LectureBookmark) -> list[str]:
+        """카테고리 이름 목록 조회"""
+        return [lc.category.name for lc in obj.lecture.lecture_categories.all()]
+
+    def get_reviews(self, obj: LectureBookmark) -> List[Dict[str, Any]]:
+        """최신 4건 리뷰 평점과 내용 반환"""
+        reviews = obj.lecture.reviews.all().order_by("-created_at")[:4]
+        return [{"rating": review.rating, "content": review.content} for review in reviews]
+
+    def get_duration(self, obj: LectureBookmark) -> str:
+        total_min = obj.lecture.duration
+        hours, minutes = divmod(total_min, 60)
+        return f"{hours:02}:{minutes:02}"
+
+
+class LectureBookmarkButtonSerializer(serializers.ModelSerializer[LectureBookmark]):
+    """북마크 추가/삭제 요청용 Serializer"""
+
+    class Meta:
+        model = LectureBookmark
+        fields = ["user", "lecture"]
+
+    def validate_lecture(self, value: Any) -> Any:
+        """유효성 검사: 전달된 lecture가 실제 존재하는지 확인"""
+        if not value.pk or (not value._state.adding and not value.__class__.objects.filter(pk=value.pk).exists()):
+            raise serializers.ValidationError("존재하지 않는 강의입니다.")
+        return value

--- a/apps/lecture/serializers/recommend_serializers.py
+++ b/apps/lecture/serializers/recommend_serializers.py
@@ -1,0 +1,46 @@
+from typing import Any, Dict, List
+
+from rest_framework import serializers
+
+from apps.lecture.models import CrawledLecture
+
+
+class RecommendedLectureSerializer(serializers.ModelSerializer[CrawledLecture]):
+    """추천 단일 강의 직렬화 ModelSerializer"""
+
+    categories = serializers.SerializerMethodField()
+    duration = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CrawledLecture
+        fields = [
+            "id",
+            "uuid",
+            "title",
+            "instructor",
+            "thumbnail_img_url",
+            "categories",
+            "difficulty",
+            "original_price",
+            "discount_price",
+            "platform",
+            "average_rating",
+            "duration",
+            "url_link",
+            "description",
+        ]
+
+    def get_categories(self, obj: CrawledLecture) -> List[Dict[str, Any]]:
+        return [{"id": lc.category.id, "name": lc.category.name} for lc in obj.lecture_categories.all()]
+
+    def get_duration(self, obj: CrawledLecture) -> str:
+        total_min = obj.duration
+        hours, minutes = divmod(total_min, 60)
+        return f"{hours:02}:{minutes:02}"
+
+
+class RecommendedLecturesDTO(serializers.Serializer[Dict[str, Any]]):
+    """사용자 닉네임과 추천 강의 리스트 DTO용 Serializer"""
+
+    nickname = serializers.CharField()
+    recommendations = RecommendedLectureSerializer(many=True)

--- a/apps/lecture/urls/bookmark_urls.py
+++ b/apps/lecture/urls/bookmark_urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from apps.lecture.views.bookmark_views import (
+    LectureBookmarkButtonAPIView,
+    LectureBookmarkListAPIView,
+)
+
+urlpatterns = [
+    path("/<int:lecture_id>/bookmarks", LectureBookmarkButtonAPIView.as_view(), name="bookmark-button"),
+    path("/me/bookmarks", LectureBookmarkListAPIView.as_view(), name="bookmark-list"),
+]

--- a/apps/lecture/urls/recommend_urls.py
+++ b/apps/lecture/urls/recommend_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.lecture.views.recommend_views import UserRecommendedLecturesAPIView
+
+urlpatterns = [
+    path("/recommendations", UserRecommendedLecturesAPIView.as_view(), name="user-recommendations"),
+]

--- a/apps/lecture/views.py
+++ b/apps/lecture/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/apps/lecture/views/bookmark_views.py
+++ b/apps/lecture/views/bookmark_views.py
@@ -1,0 +1,149 @@
+import random
+from typing import Any, List, Optional, Sequence, Union
+
+from django.db.models.query import QuerySet
+from drf_spectacular.utils import extend_schema
+from rest_framework import parsers, status
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.lecture.models import CrawledLecture
+from apps.lecture.serializers.bookmark_serializers import LectureBookmarkSerializer
+
+
+class PaginationHandlerMixin:
+    """
+    페이지네이션 기능 믹스인 클래스.
+    - PageNumberPagination을 기본 페이지네이터 클래스로 사용.
+    - paginator 인스턴스를 내부에서 캐싱하여 재사용.
+    - DRF에서는 generic view에서 자동으로 페이지네이션을 지원하지만,
+      APIView에선 이런 믹스인을 사용해 재활용.
+    """
+
+    pagination_class = PageNumberPagination
+    _paginator: Optional[PageNumberPagination] = None  # 내부 paginator 객체 캐싱
+
+    @property
+    def paginator(self) -> Optional[PageNumberPagination]:
+        """
+        paginator 인스턴스를 반환.
+        이미 생성된 객체가 없으면 pagination_class를 사용해 생성 후 캐싱.
+        """
+        if self._paginator is None:
+            if self.pagination_class is None:
+                self._paginator = None
+            else:
+                self._paginator = self.pagination_class()
+        return self._paginator
+
+    def paginate_queryset(self, queryset: Union[QuerySet[Any], Sequence[Any]]) -> Optional[Sequence[Any]]:
+        """
+        쿼리셋 혹은 리스트를 페이지 단위로 분할하여 반환.
+
+        :param queryset: QuerySet 또는 리스트 등 시퀀스 타입
+        :return: 페이지네이션된 객체 리스트 또는 None (paginator가 없을 경우)
+
+        mypy 타입 오류 방지를 위해 입력 타입을 Union[QuerySet, Sequence]로 넓혔고,
+        paginate_queryset 호출 시 view=self 인자와 관련해 mypy가 타입 불일치 경고,
+        현재 상황에서는 정상 동작을 위해 예외적으로 무시 처리(# type: ignore).
+        """
+        if self.paginator is None:
+            return None
+        return self.paginator.paginate_queryset(queryset, self.request, view=self)  # type: ignore[arg-type]
+
+    def get_paginated_response(self, data: Any) -> Response:
+        """
+        페이지네이션된 데이터 포함한 Response 객체를 반환.
+
+        DRF 시리얼라이저의 .data 속성은 ReturnDict나 ReturnList 타입이므로,
+        mypy 충돌 방지를 위해 파라미터 타입을 Any로 처리.
+        """
+        assert self.paginator is not None
+        return self.paginator.get_paginated_response(data)
+
+    @property
+    def request(self) -> Request:
+        """
+        현재 뷰에 바인딩된 Request 객체를 반환.
+        APIView에서는 self.request가 기본 제공되므로, 안전성 체크 후 반환.
+        """
+        if not hasattr(self, "request") or self.request is None:
+            raise AttributeError("Request has not been set on the view.")
+        return self.request
+
+
+class LectureBookmarkListAPIView(APIView, PaginationHandlerMixin):
+    """
+    북마크된 강의 목록 조회 API 뷰로 페이지네이션 지원.
+
+    - 권한은 AllowAny로 임시 설정되어 있으며, 실제 서비스 시 인증/권한 설정을 적용 필요.
+    - Mock 데이터를 생성해 페이지네이션 및 직렬화 과정을 시연.
+    - 추후 ORM QuerySet을 반환하도록 변경 필요,
+      select_related, prefetch_related를 사용해 N+1 문제를 방지 예정.
+    """
+
+    permission_classes = [AllowAny]  # TODO: 기능 구현 후 권한 변경
+    parser_classes = [parsers.JSONParser]
+
+    @extend_schema(
+        tags=["Lectures"],
+        summary="북마크한 강의 목록 조회 API",
+        responses={200: LectureBookmarkSerializer(many=True)},
+    )
+    def get(self, request: Request) -> Response:
+        # Mock 데이터: CrawledLecture 인스턴스 50개를 리스트로 생성 (실제 DB가 아닌 임시 예제)
+        mock_lectures: List[Any] = [
+            CrawledLecture(
+                id=i,
+                uuid=f"123e4567-e89b-12d3-a456-4266141740{i:02d}",
+                title=f"Mock 강의 {i}",
+                instructor="홍길동",
+                thumbnail_img_url="https://example.com/thumb.jpg",
+                difficulty="NORMAL",
+                original_price=120000,
+                discount_price=100000,
+                platform="inflearn",
+                average_rating=4.6,
+                duration=90 + i,
+                url_link="https://inflearn.com/course/mock",
+                description="기초부터 배우는 파이썬",
+            )
+            for i in range(1, 51)
+        ]
+
+        # 페이지네이션 처리: 쿼리셋/리스트를 페이지 단위로 잘라 반환
+        page = self.paginate_queryset(mock_lectures)
+        if page is not None:
+            # 페이지네이션된 데이터만 직렬화
+            serializer = LectureBookmarkSerializer(page, many=True)
+            # 타입 불일치 문제를 회피하기 위해 get_paginated_response에 전달 시
+            # serializer.data 자체를 넘겨도 무방 (Any 타입으로 처리)
+            return self.get_paginated_response(serializer.data)
+
+        # 페이지네이터가 없거나 pagination 대상이 아닐 경우 전체 데이터 직렬화 후 반환
+        serializer = LectureBookmarkSerializer(mock_lectures, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class LectureBookmarkButtonAPIView(APIView):
+    """
+    북마크 추가/삭제용 API 뷰.
+    - mock 랜덤 응답으로 북마크가 추가되거나 삭제된 것처럼 처리.
+    """
+
+    permission_classes = [AllowAny]  # TODO: 기능 구현 후 권한 변경
+    parser_classes = [parsers.JSONParser]
+
+    @extend_schema(
+        tags=["Lectures"],
+        summary="북마크 추가/삭제 API (Mock 랜덤 응답)",
+    )
+    def post(self, request: Request, lecture_id: int) -> Response:
+        # 랜덤으로 추가 또는 삭제 응답 발생
+        if random.choice([True, False]):
+            return Response({"detail": "북마크가 추가되었습니다."}, status=status.HTTP_201_CREATED)
+        else:
+            return Response({"detail": "북마크가 삭제되었습니다."}, status=status.HTTP_200_OK)

--- a/apps/lecture/views/recommend_views.py
+++ b/apps/lecture/views/recommend_views.py
@@ -1,0 +1,55 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework import parsers, status
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.lecture.models import CrawledLecture
+from apps.lecture.serializers.recommend_serializers import RecommendedLecturesDTO
+
+
+class UserRecommendedLecturesAPIView(APIView):
+    """사용자 맞춤 추천 강의 API 뷰"""
+
+    permission_classes = [AllowAny]  # TODO: 기능 구현 후 권한 변경
+    parser_classes = [parsers.JSONParser]
+
+    @extend_schema(
+        tags=["Lectures"],
+        summary="사용자 맞춤 추천 강의 조회 API (Mock 데이터)",
+        responses={200: RecommendedLecturesDTO},
+    )
+    def get(self, request: Request) -> Response:
+        # 임시로 Mock 강의 객체 1개 생성
+        mock_lecture = CrawledLecture(
+            id=1,
+            uuid="123e4567-e89b-12d3-a456-426614174000",
+            title="Mock 추천 강의",
+            instructor="홍길동",
+            thumbnail_img_url="https://example.com/thumb-python.jpg",
+            difficulty="NORMAL",
+            original_price=120000,
+            discount_price=100000,
+            platform="inflearn",
+            average_rating=4.6,
+            duration=90,
+            url_link="https://inflearn.com/course/mock",
+            description="기초부터 배우는 파이썬",
+        )
+
+        # 반환할 JSON에 포함할 데이터 구성
+        data_for_serialization = {
+            "nickname": "홍길동",
+            "recommendations": [mock_lecture] * 3,
+        }
+
+        # DTO용 시리얼라이저로 유효성 검사 및 직렬화 처리 위임
+        serializer = RecommendedLecturesDTO(data=data_for_serialization)
+        serializer.is_valid(raise_exception=True)
+        response_data = {
+            "detail": "맞춤 강의 추천 조회가 완료되었습니다.",
+            "data": serializer.data,
+        }
+
+        return Response(response_data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 api 문서: LECT 003, 005, 006
- 작업 요약: 강의: 사용자 맞춤 추천/북마크의 시리얼라이저, mock API 뷰, urls 추가

## 📄 상세 내용
serializers/
- LectureBookmarkSerializer, LectureBookmarkButtonSerializer
  - 북마크된 강의 정보 직렬화 및 유효성 검증

- RecommendedLectureSerializer, RecommendedLecturesDTO
  - 추천 강의 DTO용 직렬화 처리

views/
- PaginationHandlerMixin
  - APIView 기반에서 재사용 가능한 페이지네이션 기능을 믹스인 형태로 추가
  - PageNumberPagination 객체를 내부 변수에 캐싱하여 한 요청 내 반복 생성 비용 최소화
  - mypy 정적 분석 시 경고 발생하는 부분은 타입 범위 확장, 무시 처리

- LectureBookmarkListAPIView
  - 북마크된 강의 목록 반환하는 mock API 뷰

- LectureBookmarkButtonAPIView
  - 북마크 추가/삭제 mock API 뷰 (현재는 mock 랜덤 응답 처리)

- UserRecommendedLecturesAPIView
  - 사용자 맞춤 추천 강의 mock API 뷰
  - 닉네임과 추천 강의 리스트를 포함하는 DTO를 사용하여 응답 직렬화

urls/
- recommend, bookmark_urls.py

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
