### PR TITLE
✨ feat: 메시지 전송 Spec API 작성

### DIFF
--- a/apps/chat/serializers/chat_serializers.py
+++ b/apps/chat/serializers/chat_serializers.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class ChatMessageCreateRequestSerializer(serializers.Serializer[Any]):
+    content = serializers.CharField(required=True)
+
+
+class ChatMessageResponseSerializer(serializers.Serializer[Any]):
+    message_id = serializers.IntegerField()
+    sender_id = serializers.IntegerField()
+    study_group_id = serializers.IntegerField()
+    content = serializers.CharField()
+    file_url = serializers.URLField(allow_null=True)
+    created_at = serializers.DateTimeField()

--- a/apps/chat/urls/chat_urls.py
+++ b/apps/chat/urls/chat_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.chat.views.chat_views import ChatMessageCreateAPIView
+
+urlpatterns = [
+    path("study-groups/<int:study_group_id>/messages", ChatMessageCreateAPIView.as_view(), name="chat-message-create"),
+]

--- a/apps/chat/views/chat_views.py
+++ b/apps/chat/views/chat_views.py
@@ -1,0 +1,61 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.chat.serializers.chat_serializers import (
+    ChatMessageCreateRequestSerializer,
+    ChatMessageResponseSerializer,
+)
+
+
+class ChatMessageCreateAPIView(APIView):
+    @extend_schema(
+        tags=["Chat"],
+        summary="메시지 전송 API",
+        description="""
+        특정 스터디 그룹에 채팅 메시지를 전송합니다.
+        인증된 사용자만 메시지를 전송할 수 있으며, 요청 본문으로 메시지 내용을 받습니다.
+        """,
+        request=ChatMessageCreateRequestSerializer,
+        responses={
+            201: ChatMessageResponseSerializer,
+            403: {
+                "description": "스터디 그룹 멤버가 아님",
+                "example": {
+                    "status": "error",
+                    "code": "NOT_A_MEMBER",
+                    "message": "해당 사용자는 스터디 그룹 멤버가 아닙니다.",
+                    "data": None,
+                },
+            },
+        },
+        parameters=[
+            OpenApiParameter(
+                name="study_group_id",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.PATH,
+                description="그룹 ID",
+                required=True,
+            ),
+        ],
+    )
+    def post(self, request: Request, study_group_id: int) -> Response:  # Add type hints
+        # Spec API 단계에서는 비즈니스 로직을 구현하지 않습니다.
+        # 여기서는 단순히 시리얼라이저를 통한 요청 유효성 검사 및 응답 구조만 보여줍니다.
+        request_serializer = ChatMessageCreateRequestSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+
+        # 임시 응답 데이터 (실제 로직은 기능 구현 단계에서 추가)
+        response_data = {
+            "message_id": 1,  # 임시 ID
+            "sender_id": request.user.id if request.user.is_authenticated else 0,  # 임시 sender_id
+            "study_group_id": study_group_id,
+            "content": request_serializer.validated_data["content"],
+            "file_url": None,
+            "created_at": "2025-10-15T10:30:00Z",  # 임시 시간
+        }
+        response_serializer = ChatMessageResponseSerializer(response_data)
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,6 +8,7 @@ from drf_spectacular.views import (
 )
 
 urlpatterns: list[URLPattern | URLResolver] = [
+    path("api/v1/", include("apps.chat.urls.chat_urls")),
     path("api/lectures/", include("apps.lecture.urls")),
 ]
 


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #44 
- 작업 요약: 메시지 전송 API Spec API 구현 및 누락된 파일 복구(models 관련 데이터)

## 📄 상세 내용

* 주요 변경 사항 1
- [x] API 명세서에 기반하여 메시지 전송 API의 뼈대(Spec API)를 구현

* 세부 내역:
- [x] apps/chat/serializers/chat_serializers.py: 
- 메시지 생성 요청 및 응답을 위한 시리얼라이(ChatMessageCreateRequestSerializer, ChatMessageResponseSerializer)를 정의
   
- [x] apps/chat/urls/chat_urls.py: 
- 메시지 전송 API의 URL 패턴을 정의 (study-groups/<int:study_group_id>/messages)
   
- [x] apps/chat/views/chat_views.py: 
- APIView를 상속받아 post 메서드를 구현하고, @extend_schema 데코레이터를 활용하여 Swagger 문서화를 위한 명세를 추가 
- (비즈니스 로직은 포함하지 않음)
   
- [x] config/urls.py: 
- 프로젝트 메인 URL 설정에 chat 앱의 URL을 /api/v1/ 경로 아래에 포함
   
* 주요 변경 사항 2
- [x] 누락되었던 chat 앱의 핵심 모델 파일들을 복구하고, 이로 인해 발생했던 mypy 오류를 해결

* 세부 내역:
- [x] apps/chat/models/__init__.py, chat_message.py, last_read_message.py 파일들을 develop 브랜치로부터 복구
   
- [x] 모델 파일 복구 후 apps/chat/serializers/chat_serializers.py 및 apps/chat/views/chat_views.py에서 발생했던 mypy 타입 오류(Missing type parameters for generic type "Serializer", Function is missing a type annotation)를 수정
   
* 주요 변경 사항 3
- [x] 구현된 코드의 품질을 확보하고, 데이터베이스 변경사항을 적용

* 세부 내역:
- [x] isort, black을 실행하여 코드 포매팅을 완료
- [x] mypy 정적 타입 검사 통과


## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- [x] CI/CD 동작 중 캐시 오류로 검증 통과 불가 -> 깃허브 액션에서 수동으로 캐시 삭제 후 정상적으로 진행 완료

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
