### PR TITLE
Feature/fix lectures swagger 태그 통일, 누락 스키마 추가

### DIFF
--- a/apps/lecture/views/bookmark_views.py
+++ b/apps/lecture/views/bookmark_views.py
@@ -30,7 +30,7 @@ class LectureBookmarkListCreateView(APIView):
 
     @extend_schema(
         tags=["Lectures"],
-        summary="로그인 유저 북마크 목록 조회 및 북마크 추가 API (Mock)",
+        summary="강의 북마크 목록 조회 API (Mock)",
         responses={
             200: LectureBookmarkListSerializer(many=True),
             201: {"description": "북마크가 추가되었습니다."},
@@ -74,6 +74,16 @@ class LectureBookmarkListCreateView(APIView):
         serializer = LectureBookmarkListSerializer(mock_bookmarks, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        tags=["Lectures"],
+        summary="강의 북마크 추가 API (Mock)",
+        request=LectureBookmarkCreateSerializer,
+        responses={
+            201: {"description": "북마크가 추가되었습니다."},
+            400: {"description": "잘못된 요청 또는 중복 북마크"},
+            404: {"description": "존재하지 않는 강의입니다."},
+        },
+    )
     def post(self, request: Request) -> Response:
         # 1. context={"request": request} 제거 (필수 아님, 일반적인 request 정보는 남겨도 무방)
         serializer = LectureBookmarkCreateSerializer(data=request.data)

--- a/apps/lecture/views/lecture_views.py
+++ b/apps/lecture/views/lecture_views.py
@@ -29,7 +29,7 @@ class LectureListView(APIView):
 
     @extend_schema(
         operation_id="v1_lecture_list",
-        tags=["Lecture"],
+        tags=["Lectures"],
         summary="강의 목록 조회 API",
         responses={200: LectureListSerializer(many=True)},
     )
@@ -97,7 +97,7 @@ class LectureReviewListView(APIView):
 
     @extend_schema(
         operation_id="v1_lecture_review_list",
-        tags=["Lecture"],
+        tags=["Lectures"],
         summary="강의 리뷰 조회 API",
         responses={200: LectureReviewSerializer(many=True)},
     )


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: 로컬 swagger 문서 실행 시 태그 오류 확인. 해당 부분 수정

## 📄 상세 내용
- [ ] lecture_view.py 의 tag "Lectures" 로 통일
- [ ] bookmark_views.py 의 post method에 @extend_schema 추가

## 📸 스크린샷 (선택)
- 수정 전
<img width="1374" height="466" alt="스크린샷 2025-10-23 오전 11 03 14" src="https://github.com/user-attachments/assets/59949b73-3b6f-4909-8da0-73e625431495" />

- 수정후
<img width="1351" height="342" alt="스크린샷 2025-10-23 오전 11 04 29" src="https://github.com/user-attachments/assets/8a5fc56a-5e8c-49ba-a3af-150eeea3d16d" />

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
