### PR TITLE
내 정보 조회 api 생성

### DIFF
--- a/apps/users/serializers/user_profile_serializers.py
+++ b/apps/users/serializers/user_profile_serializers.py
@@ -27,7 +27,6 @@ class UserProfileSerializer(serializers.ModelSerializer[Any]):
             "name",
             "phone_number",
             "birthday",
-            "profile_image_url",
             "created_at",
         ]
         read_only_fields = fields

--- a/apps/users/serializers/user_profile_serializers.py
+++ b/apps/users/serializers/user_profile_serializers.py
@@ -27,6 +27,7 @@ class UserProfileSerializer(serializers.ModelSerializer[Any]):
             "name",
             "phone_number",
             "birthday",
+            "profile_image_url",
             "created_at",
         ]
         read_only_fields = fields

--- a/apps/users/serializers/user_profile_serializers.py
+++ b/apps/users/serializers/user_profile_serializers.py
@@ -27,7 +27,7 @@ class UserProfileSerializer(serializers.ModelSerializer[Any]):
             "name",
             "phone_number",
             "birthday",
-            "profile_image_url",
+            "profile_img_url",  # 모델 필드 이름과 일치
             "created_at",
         ]
         read_only_fields = fields
@@ -49,8 +49,8 @@ class UserProfileUpdateSerializer(serializers.ModelSerializer[Any]):
 
     class Meta:
         model = User
-        fields = ("nickname", "profile_image_url", "phone_number", "verify_token")
-        extra_kwargs = {"profile_image_url": {"required": False}}
+        fields = ("nickname", "profile_img_url", "phone_number", "verify_token")
+        extra_kwargs = {"profile_img_url": {"required": False}}
 
 
 class UserProfilePasswordUpdateSerializer(serializers.Serializer[Dict[str, Any]]):

--- a/apps/users/tests/test_user_profile_api.py
+++ b/apps/users/tests/test_user_profile_api.py
@@ -54,7 +54,4 @@ class MeAPITest(APITestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 401)
-        self.assertEqual(
-            response.data["detail"],
-            "자격 인증데이터(authentication credentials)가 제공되지 않았습니다."
-        )
+        self.assertEqual(response.data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")

--- a/apps/users/tests/test_user_profile_api.py
+++ b/apps/users/tests/test_user_profile_api.py
@@ -19,7 +19,7 @@ class MeAPITest(APITestCase):
             name="홍길동",
             phone_number="01012345678",
             birthday="1998-01-23",
-            gender="M",  # gender 필드 추가
+            gender="M",
             is_active=True,
         )
 
@@ -34,16 +34,16 @@ class MeAPITest(APITestCase):
         """
         로그인한 사용자가 /api/v1/me 조회 성공
         """
-        url = reverse("users:me")  # urls.py에서 name='me'이고, app_name='users'인 경우
+        url = reverse("users:me")
         response = self.client.get(url)
 
         # 검증
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["data"]["email"], self.user.email)
-        self.assertEqual(response.data["data"]["nickname"], self.user.nickname)
-        self.assertEqual(response.data["data"]["name"], self.user.name)
-        self.assertIn("profile_img_url", response.data["data"])  # 필드 존재 확인
-        self.assertIn("created_at", response.data["data"])
+        self.assertEqual(response.data["email"], self.user.email)
+        self.assertEqual(response.data["nickname"], self.user.nickname)
+        self.assertEqual(response.data["name"], self.user.name)
+        self.assertIn("profile_img_url", response.data)  # 필드 존재 확인
+        self.assertIn("created_at", response.data)
 
     def test_me_unauthorized(self) -> None:
         """
@@ -54,4 +54,7 @@ class MeAPITest(APITestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 401)
-        self.assertEqual(response.data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
+        self.assertEqual(
+            response.data["detail"],
+            "자격 인증데이터(authentication credentials)가 제공되지 않았습니다."
+        )

--- a/apps/users/tests/test_user_profile_api.py
+++ b/apps/users/tests/test_user_profile_api.py
@@ -1,0 +1,62 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
+
+User = get_user_model()
+
+
+class MeAPITest(APITestCase):
+    def setUp(self) -> None:
+        """
+        테스트용 유저 생성 및 JWT 인증 설정
+        """
+        self.user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            nickname="ozdev",
+            name="홍길동",
+            phone_number="01012345678",
+            birthday="1998-01-23",
+            is_active=True,
+        )
+
+        # JWT 토큰 발급
+        refresh = RefreshToken.for_user(self.user)
+        self.access_token = str(refresh.access_token)
+
+        # 토큰 출력 (인증 확인용)
+        print("Access Token:", self.access_token)
+
+        # 인증 헤더 설정
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.access_token}")
+
+    def test_me_success(self) -> None:
+        """
+        로그인한 사용자가 /api/v1/me 조회 성공
+        """
+        url = reverse("users:me")  # 앱 네임스페이스 포함
+        response = self.client.get(url)
+
+        # 인증 확인 로그 (선택)
+        print("Response status:", response.status_code)
+        print("Response data:", response.data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["email"], self.user.email)
+        self.assertEqual(response.data["data"]["nickname"], self.user.nickname)
+        self.assertEqual(response.data["data"]["name"], self.user.name)
+
+    def test_me_unauthorized(self) -> None:
+        """
+        인증되지 않은 요청은 401 반환
+        """
+        self.client.credentials()  # 인증 헤더 제거
+        url = reverse("users:me")  # 앱 네임스페이스 포함
+        response = self.client.get(url)
+
+        # 인증 실패 로그 (선택)
+        print("Unauthorized response status:", response.status_code)
+        print("Unauthorized response data:", response.data)
+
+        self.assertEqual(response.status_code, 401)

--- a/apps/users/tests/test_user_profile_api.py
+++ b/apps/users/tests/test_user_profile_api.py
@@ -19,7 +19,7 @@ class MeAPITest(APITestCase):
             name="홍길동",
             phone_number="01012345678",
             birthday="1998-01-23",
-            gender="M",           # gender 필드 추가
+            gender="M",  # gender 필드 추가
             is_active=True,
         )
 
@@ -54,7 +54,4 @@ class MeAPITest(APITestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 401)
-        self.assertEqual(
-            response.data["detail"],
-            "자격 인증데이터(authentication credentials)가 제공되지 않았습니다."
-        )
+        self.assertEqual(response.data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")

--- a/apps/users/tests/test_user_profile_api.py
+++ b/apps/users/tests/test_user_profile_api.py
@@ -11,6 +11,7 @@ class MeAPITest(APITestCase):
         """
         테스트용 유저 생성 및 JWT 인증 설정
         """
+        # 테스트용 유저 생성
         self.user = User.objects.create_user(
             email="user@example.com",
             password="password123",
@@ -18,15 +19,13 @@ class MeAPITest(APITestCase):
             name="홍길동",
             phone_number="01012345678",
             birthday="1998-01-23",
+            gender="M",           # gender 필드 추가
             is_active=True,
         )
 
         # JWT 토큰 발급
         refresh = RefreshToken.for_user(self.user)
         self.access_token = str(refresh.access_token)
-
-        # 토큰 출력 (인증 확인용)
-        print("Access Token:", self.access_token)
 
         # 인증 헤더 설정
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.access_token}")
@@ -35,28 +34,27 @@ class MeAPITest(APITestCase):
         """
         로그인한 사용자가 /api/v1/me 조회 성공
         """
-        url = reverse("users:me")  # 앱 네임스페이스 포함
+        url = reverse("users:me")  # urls.py에서 name='me'이고, app_name='users'인 경우
         response = self.client.get(url)
 
-        # 인증 확인 로그 (선택)
-        print("Response status:", response.status_code)
-        print("Response data:", response.data)
-
+        # 검증
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["data"]["email"], self.user.email)
         self.assertEqual(response.data["data"]["nickname"], self.user.nickname)
         self.assertEqual(response.data["data"]["name"], self.user.name)
+        self.assertIn("profile_img_url", response.data["data"])  # 필드 존재 확인
+        self.assertIn("created_at", response.data["data"])
 
     def test_me_unauthorized(self) -> None:
         """
         인증되지 않은 요청은 401 반환
         """
         self.client.credentials()  # 인증 헤더 제거
-        url = reverse("users:me")  # 앱 네임스페이스 포함
+        url = reverse("users:me")
         response = self.client.get(url)
 
-        # 인증 실패 로그 (선택)
-        print("Unauthorized response status:", response.status_code)
-        print("Unauthorized response data:", response.data)
-
         self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.data["detail"],
+            "자격 인증데이터(authentication credentials)가 제공되지 않았습니다."
+        )

--- a/apps/users/urls/user_urls.py
+++ b/apps/users/urls/user_urls.py
@@ -4,6 +4,6 @@ from apps.users.views.user_profile_views import MeView
 from apps.users.views.user_signup_views import UserSignupView
 
 urlpatterns: list[URLPattern | URLResolver] = [
-    path("users", UserSignupView.as_view(), name="signup"),
-    path("me", MeView.as_view(), name="me"),
+    path("users/", UserSignupView.as_view(), name="signup"),  # /api/v1/users/
+    path("users/me/", MeView.as_view(), name="me"),  # /api/v1/users/me/
 ]

--- a/apps/users/urls/user_urls.py
+++ b/apps/users/urls/user_urls.py
@@ -1,7 +1,9 @@
 from django.urls import URLPattern, URLResolver, path
 
+from apps.users.views.user_profile_views import MeView
 from apps.users.views.user_signup_views import UserSignupView
 
 urlpatterns: list[URLPattern | URLResolver] = [
     path("users", UserSignupView.as_view(), name="signup"),
+    path("me", MeView.as_view(), name="me"),
 ]

--- a/apps/users/views/user_profile_views.py
+++ b/apps/users/views/user_profile_views.py
@@ -1,0 +1,30 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.serializers.user_profile_serializers import UserProfileSerializer
+
+
+class MeView(APIView):
+    """
+    내 정보 조회 API
+    - GET /api/v1/me
+    - 로그인한 사용자의 프로필 정보를 반환
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=["Users"],
+        summary="내 정보 조회",
+        description="로그인한 사용자가 본인 정보를 조회한다.",
+        responses=UserProfileSerializer,
+    )
+    def get(self, request: Request) -> Response:
+        """
+        현재 로그인한 사용자 정보 반환
+        """
+        serializer = UserProfileSerializer(request.user)
+        return Response({"detail": "내 정보를 조회합니다.", "data": serializer.data})

--- a/apps/users/views/user_profile_views.py
+++ b/apps/users/views/user_profile_views.py
@@ -27,4 +27,4 @@ class MeView(APIView):
         현재 로그인한 사용자 정보 반환
         """
         serializer = UserProfileSerializer(request.user)
-        return Response({"detail": "내 정보를 조회합니다.", "data": serializer.data})
+        return Response(serializer.data, status=200)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 로그인한 사용자의 정보를 반환하는 API (/api/v1/me) 생성

## 📄 상세 내용
 -user_profile_views.py에 MeRetrieveAPIView 생성
 -JWT 인증을 사용하여 로그인 사용자만 접근 가능하도록 설정
 -DRF 스웨거 문서화 적용 (drf_spectacular 스키마 사용)

## 📸 스크린샷 (선택)
-없음 (API 테스트는 Postman/Swagger에서 확인 가능)

## 📝 기타 참고 사항
-로그인되지 않은 사용자는 401 Unauthorized 반환
-앞으로 사용자 관련 API 확장 시 기반으로 사용 예정

## 🧪 PR Checklist
-커밋 메시지 컨벤션에 맞게 작성했습니다.
-변경 사항에 대한 테스트를 했습니다. (기능 테스트 완료, 인증/비인증 경우 확인)