### PR TITLE
✨ 관리자 탈퇴 회원 목록 조회용 serializer 추가

### DIFF
--- a/apps/users/serializers/admin_withdrawals_serializer.py
+++ b/apps/users/serializers/admin_withdrawals_serializer.py
@@ -1,0 +1,36 @@
+from typing import Any, Dict
+
+from rest_framework import serializers
+
+
+class UserWithdrawalSerializer(serializers.Serializer[Dict[str, Any]]):
+    id = serializers.IntegerField()
+    email = serializers.EmailField()
+    name = serializers.CharField()
+    role = serializers.CharField()
+    birthday = serializers.DateField()
+    reason = serializers.CharField()
+    created_at = serializers.DateTimeField()
+
+
+class PaginationSerializer(serializers.Serializer[Dict[str, Any]]):
+    page = serializers.IntegerField()
+    limit = serializers.IntegerField()
+    total_items = serializers.IntegerField()
+    total_pages = serializers.IntegerField()
+
+
+class WithdrawalListResponseSerializer(serializers.Serializer[Dict[str, Any]]):
+    detail = serializers.CharField(read_only=True)
+
+    # ✅ DictField 제거 → mypy에서 Serializer 기본 반환 타입(ReturnDict)과 충돌 방지
+    def to_representation(self, instance: Dict[str, Any]) -> Dict[str, Any]:
+        users = UserWithdrawalSerializer(instance.get("users", []), many=True).data
+        pagination = PaginationSerializer(instance.get("pagination", {})).data
+        return {
+            "detail": "회원 탈퇴 내역 목록 조회에 성공하였습니다.",
+            "data": {
+                "users": users,
+                "pagination": pagination,
+            },
+        }


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 관리자 탈퇴 회원 목록 조회 API용 시리얼라이저

## 📄 상세 내용
- admin_withdrawals_serializer.py 파일 생성
- 탈퇴 회원 목록 조회용 시리얼라이저 구현 (회원 ID, 이메일, 이름, 역할, 생년월일, 탈퇴 사유, 생성일 포함)
- 페이지네이션 및 필터링(query: start_date, end_date, reason, keyword) 기능 반영

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
