### PR TITLE
[Feature/users recovery/find email/juhyun] 이메일 찾기 API 작성

### DIFF
--- a/apps/users/permissions.py
+++ b/apps/users/permissions.py
@@ -44,16 +44,18 @@ class PhoneVerifiedPermission(BasePermission):
             self.message = "휴대폰 검증 토큰이 필요합니다."
             return False
 
-        phone_number = request.data.get("phone_number") or request.query_params.get("phone_number")
-        if not phone_number:
-            self.message = "전화번호가 필요합니다."
-            return False
-
         claims = verify_and_consume(
             token,
             expected_purpose=purpose,
-            expected_sub=phone_number,
         )
+
+        # 토큰 안에 들어있는 휴대폰 번호 사용
+        token_phone = claims.get("to")
+
+        phone_number = request.data.get("phone_number") or request.query_params.get("phone_number") or token_phone
+        if not phone_number:
+            self.message = "전화번호가 필요합니다."
+            return False
 
         setattr(request, "phone_verify_claims", claims)
         return True

--- a/apps/users/serializers/find_email_serializers.py
+++ b/apps/users/serializers/find_email_serializers.py
@@ -3,9 +3,6 @@ from typing import TYPE_CHECKING, Any, Dict
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
-if TYPE_CHECKING:
-    from apps.users.models import User as UserModel
-
 User = get_user_model()
 
 

--- a/apps/users/serializers/find_email_serializers.py
+++ b/apps/users/serializers/find_email_serializers.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Dict
 
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
@@ -9,20 +9,14 @@ if TYPE_CHECKING:
 User = get_user_model()
 
 
-class EmailLookupSerializer(serializers.ModelSerializer[UserModel]):
+class FindEmailSerializer(serializers.Serializer[Dict[str, Any]]):
     """
-    아이디(이메일) 찾기 Serializer
-    - User 모델 기반
-    - 이메일만 반환 (마스킹 처리된 값)
+    아이디(이메일) 찾기 응답 전용 Serializer
     """
 
-    email = serializers.SerializerMethodField()
+    email = serializers.CharField()
 
-    class Meta:
-        model = User
-        fields = ["email"]
-
-    def to_representation(self, obj: UserModel) -> dict[str, Any]:
+    def to_representation(self, obj: dict[str, str]) -> dict[str, str]:
         """
         응답 직렬화 시점에 이메일 마스킹 처리
         예: kimkim@gmail.com → k****m@gmail.com
@@ -30,7 +24,11 @@ class EmailLookupSerializer(serializers.ModelSerializer[UserModel]):
         data = super().to_representation(obj)
         email = data.get("email", "")
 
+        if "@" not in email:
+            return data  # 안전하게
+
         name, domain = email.split("@", 1)
+
         if len(name) <= 1:
             masked_name = name
         elif len(name) == 2:

--- a/apps/users/tests/test_find_email.py
+++ b/apps/users/tests/test_find_email.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+
+from apps.core.utils.isolated_cache_testcase import IsolatedRedisTestClient
+from apps.users.enums import PhoneVerificationPurpose
+from apps.users.utils.phone_normalize import normalize_kr_phone
+from apps.users.utils.verify_token import issue_verify_token
+
+User = get_user_model()
+
+
+class FindEmailTests(IsolatedRedisTestClient):
+    """
+    이메일 찾기 API 통합 테스트
+    """
+
+    def setUp(self) -> None:
+        self.url = reverse("users:user_find_email")
+        self.user = User.objects.create_user(
+            email="me@example.com",
+            password="pw123!!",
+            nickname="me_nick",
+            name="나",
+            phone_number="01012345678",
+            gender="M",
+            birthday="1999-01-01",
+            is_active=True,
+        )
+
+    def _issue_find_email_token(self, *, phone: str) -> str:
+        return issue_verify_token(
+            sub=phone,
+            to=normalize_kr_phone(phone),
+            purpose=PhoneVerificationPurpose.FIND_EMAIL,
+        )
+
+    def _headers(self, *, token: str) -> dict[str, str]:
+        return {"HTTP_X_PHONE_VERIFY_TOKEN": token}
+
+    def test_success_find_email_once(self) -> None:
+        """
+        1) 토큰 발급
+        2) 헤더에 실어서 GET
+        3) 이메일 마스킹되어서 반환
+        """
+        token = self._issue_find_email_token(phone=self.user.phone_number)
+
+        resp = self.client.get(
+            self.url,
+            **self._headers(token=token),  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        body = resp.json()
+        self.assertEqual(body["detail"], "이메일 찾기 완료.")
+        self.assertIn("email", body["data"])
+        # 마스킹이 되었는지 확인
+        self.assertNotEqual(body["data"]["email"], self.user.email)
+        self.assertTrue(body["data"]["email"].endswith("@example.com"))
+
+    def test_permission_missing_token_returns_403(self) -> None:
+        """
+        토큰 미제공 → 퍼미션에서 403
+        """
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("토큰", str(resp.data))
+
+    def test_token_is_one_time_consumed(self) -> None:
+        """
+        같은 토큰 두 번 쓰면 두 번째는 퍼미션에서 403
+        """
+        token = self._issue_find_email_token(phone=self.user.phone_number)
+
+        # 1회차: 성공
+        r1 = self.client.get(
+            self.url,
+            **self._headers(token=token),  # type: ignore[arg-type]
+        )
+        self.assertEqual(r1.status_code, status.HTTP_200_OK)
+
+        # 2회차: 같은 토큰 재사용 → verify_and_consume 에서 예외 → permission 단계라 403
+        r2 = self.client.get(
+            self.url,
+            **self._headers(token=token),  # type: ignore[arg-type]
+        )
+        self.assertEqual(r2.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_not_found_returns_404(self) -> None:
+        """
+        토큰은 정상인데 DB에 없는 번호일 때
+        """
+        token = self._issue_find_email_token(phone="01099998888")
+
+        resp = self.client.get(
+            self.url,
+            **self._headers(token=token),  # type: ignore[arg-type]
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(resp.json()["error"], "존재하지 않는 사용자입니다.")

--- a/apps/users/urls/user_urls.py
+++ b/apps/users/urls/user_urls.py
@@ -1,5 +1,6 @@
 from django.urls import URLPattern, URLResolver, path
 
+from apps.users.views.find_email_views import FindEmailView
 from apps.users.views.password_reset_views import PasswordResetView
 from apps.users.views.user_profile_views import (
     MeView,
@@ -27,4 +28,5 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("users/dup-nickname", UserDupNicknameView.as_view(), name="dup_nickname"),
     # recovery
     path("users/reset-password", PasswordResetView.as_view(), name="user_reset_password"),
+    path("users/find-email", FindEmailView.as_view(), name="user_find_email"),
 ]

--- a/apps/users/utils/phone_normalize.py
+++ b/apps/users/utils/phone_normalize.py
@@ -8,3 +8,19 @@ def normalize_kr_phone(raw: str) -> str:
     """
     validate_korean_phone(raw)
     return f"+82{raw[1:]}"
+
+
+def denormalize_kr_phone(e164: str) -> str:
+    """
+    입력: '+8210XXXXXXXX' (E.164)
+    출력: '010XXXXXXXX' (국내 표준 형식)
+    """
+    if not e164.startswith("+82"):
+        raise ValueError("E.164 형식이 아닙니다. '+82'로 시작해야 합니다.")
+
+    # +82 다음의 번호를 국내 형식으로 변환
+    local = e164[3:]
+    if not local.startswith("10"):
+        raise ValueError("한국 휴대폰 번호 형식(+8210...)이 아닙니다.")
+
+    return f"0{local}"

--- a/apps/users/views/find_email_views.py
+++ b/apps/users/views/find_email_views.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
+from rest_framework import serializers, status
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.enums import PhoneVerificationPurpose
+from apps.users.permissions import PhoneVerifiedPermission
+from apps.users.serializers.find_email_serializers import FindEmailSerializer
+from apps.users.utils.phone_normalize import denormalize_kr_phone, normalize_kr_phone
+
+User = get_user_model()
+
+
+def _header(request: Request, name: str) -> Optional[str]:
+    return request.headers.get(name)
+
+
+@extend_schema(
+    tags=["Users"],
+    summary="이메일 찾기",
+    description="휴대폰 인증을 거친 뒤 이메일을 찾습니다.",
+    responses=inline_serializer(
+        name="PhoneVerificationSendCodeResponse",
+        fields={
+            "detail": serializers.CharField(),
+            "data": FindEmailSerializer(),
+        },
+    ),
+    parameters=[
+        OpenApiParameter(
+            name="X-Phone-Verify-Token",
+            type=str,
+            location=OpenApiParameter.HEADER,
+            required=True,
+            description="휴대폰 인증 토큰",
+        ),
+    ],
+)
+class FindEmailView(APIView):
+    # 인증 비활성화
+    authentication_classes: tuple[type[BaseAuthentication], ...] = ()
+    permission_classes = [PhoneVerifiedPermission]
+    purpose = PhoneVerificationPurpose.FIND_EMAIL
+
+    def get(self, request: Request) -> Response:
+        claims = getattr(request, "phone_verify_claims", None)
+        if not claims:
+            return Response({"error": "토큰이 유효하지 않습니다."}, status=status.HTTP_401_UNAUTHORIZED)
+
+        phone = claims.get("to")
+        try:
+            user = User.objects.get(phone_number=denormalize_kr_phone(phone), is_active=True)
+        except User.DoesNotExist:
+            return Response({"error": "존재하지 않는 사용자입니다."}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = FindEmailSerializer({"email": user.email})
+        return Response(
+            {"detail": "이메일 찾기 완료.", "data": serializer.data},
+            status=status.HTTP_200_OK,
+        )

--- a/apps/users/views/password_reset_views.py
+++ b/apps/users/views/password_reset_views.py
@@ -48,8 +48,6 @@ class PasswordResetView(APIView):
         req_serializer = PasswordResetSerializer(data=request.data)
         req_serializer.is_valid(raise_exception=True)
 
-        idem_key = _header(request, "Idempotency-Key")
-
         reset_password(
             claims=claims,
             new_password=req_serializer.validated_data["new_password"],

--- a/apps/users/views/password_reset_views.py
+++ b/apps/users/views/password_reset_views.py
@@ -32,13 +32,6 @@ def _header(request: Request, name: str) -> Optional[str]:
             required=True,
             description="이메일 인증 토큰",
         ),
-        OpenApiParameter(
-            name="Idempotency-Key",
-            type=str,
-            location=OpenApiParameter.HEADER,
-            required=False,
-            description="중복 요청 방지 키 (UUID 권장)",
-        ),
     ],
 )
 class PasswordResetView(APIView):


### PR DESCRIPTION
## ✅ PR 요약
- 이메일 찾기 API 작성

## 📄 상세 내용
- [x] 이메일 찾기 API Serializer, View, Url, Test code 작성
- [x] 헤더로 전달된 토큰에서 휴대폰 번호를 가져와 사용할 수 있도록 permission 수정 
- [x] 위의 경우 +82 형태로 된 휴대폰 번호를 다시 010 형태로 돌려 사용자 정보를 찾을 수 있도록 관련 모듈 추가(denormalize_kr_phone)

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- 이메일 찾기는 기능이 단순해서 service 분리하지 않고 view에서 처리했습니다.

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
