### PR TITLE
✨ feat : WebSocket 메세지 삭제 기능 구현

### DIFF
--- a/apps/chat/consumers.py
+++ b/apps/chat/consumers.py
@@ -1,7 +1,7 @@
 # apps/chat/consumers.py
 
 import json
-from typing import Any
+from typing import Any, cast
 
 from channels.db import database_sync_to_async  # type: ignore[import-untyped]
 from channels.generic.websocket import (  # type: ignore[import-untyped]
@@ -9,10 +9,13 @@ from channels.generic.websocket import (  # type: ignore[import-untyped]
 )
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser
+from rest_framework.exceptions import APIException
 
 from apps.chat.models import ChatMessage, LastReadMessage
 from apps.studies.models.groups import GroupMember, StudyGroup
+from apps.users.models import User
 
+from .exceptions import ChatMessageNotFoundException, ChatMessageNotSenderException
 from .services import ChatMessageService
 
 
@@ -60,21 +63,41 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
         message_type = content.get("type")
         user = self.scope["user"]
 
-        if message_type == "chat.message":
-            message_content = content.get("content", "").strip()  # Ensure message_content is always a string
+        try:
+            if message_type == "chat.message":
+                message_content = content.get("content", "").strip()
+                message = None
+                if user.is_authenticated:
+                    message = await self.create_chat_message(user, message_content)
 
-            if user.is_authenticated:
-                await self.create_chat_message(user, message_content)
+                # Send message to room group
+                await self.channel_layer.group_send(
+                    self.room_group_name,
+                    {
+                        "type": "chat_message",
+                        "message_id": message.id if message else None,
+                        "message": message_content,
+                        "sender_id": user.id if user.is_authenticated else None,
+                    },
+                )
+            elif message_type == "chat.delete_message":
+                message_id = content.get("message_id")
 
-            # Send message to room group
-            await self.channel_layer.group_send(
-                self.room_group_name,
-                {
-                    "type": "chat_message",
-                    "message": message_content,
-                    "sender_id": user.id if user.is_authenticated else None,
-                },
-            )
+                if user.is_authenticated and message_id:
+                    await self.delete_chat_message(user, message_id)
+        except APIException as e:
+            await self.send_json({"type": "error", "code": e.default_code, "message": e.default_detail})
+
+    async def _get_message_and_verify_sender(self, user: User, message_id: int) -> ChatMessage:
+        try:
+            message = await ChatMessage.objects.aget(id=message_id, study_group_id=self.study_group_id)
+        except ChatMessage.DoesNotExist:
+            raise ChatMessageNotFoundException
+
+        if message.sender != user:
+            raise ChatMessageNotSenderException
+
+        return message
 
     async def is_valid_study_group(self) -> bool:
         return await StudyGroup.objects.filter(id=self.study_group_id).aexists()
@@ -84,26 +107,57 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
             return False
         return await GroupMember.objects.filter(study_group_id=self.study_group_id, user=user).aexists()
 
-    async def create_chat_message(self, user: AbstractBaseUser, content: str) -> None:
+    async def create_chat_message(self, user: User, content: str) -> ChatMessage:
         """
         Asynchronously creates a chat message in the database.
         """
         study_group = await StudyGroup.objects.aget(id=self.study_group_id)
-        await database_sync_to_async(ChatMessageService.create_chat_message)(
+        message = await database_sync_to_async(ChatMessageService.create_chat_message)(
             sender=user,
             study_group=study_group,
             content=content,
         )
+        return cast(ChatMessage, message)
+
+    async def delete_chat_message(self, user: User, message_id: int) -> None:
+        message = await self._get_message_and_verify_sender(user, message_id)
+        await database_sync_to_async(ChatMessageService.delete_chat_message)(message=message)
+
+        # Broadcast the deleted message
+        await self.channel_layer.group_send(
+            self.room_group_name,
+            {
+                "type": "chat_message_deleted",
+                "message_id": message_id,
+                "deleter_id": user.id,
+            },
+        )
 
     # Receive message from room group
     async def chat_message(self, event: dict[str, Any]) -> None:
+        message_id = event["message_id"]
         message = event["message"]
         sender_id = event["sender_id"]
 
         # Send message to WebSocket
         await self.send(
             text_data=json.dumps(
-                {"type": "chat.message", "message": message, "sender_id": sender_id},
+                {"type": "chat.message", "message_id": message_id, "message": message, "sender_id": sender_id},
+                ensure_ascii=False,
+            )
+        )
+
+    async def chat_message_deleted(self, event: dict[str, Any]) -> None:
+        message_id = event["message_id"]
+        deleter_id = event["deleter_id"]
+
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": "chat.message.deleted",
+                    "message_id": message_id,
+                    "deleter_id": deleter_id,
+                },
                 ensure_ascii=False,
             )
         )

--- a/apps/chat/exceptions.py
+++ b/apps/chat/exceptions.py
@@ -1,0 +1,15 @@
+# apps/chat/exceptions.py
+
+from rest_framework.exceptions import APIException
+
+
+class ChatMessageNotFoundException(APIException):
+    status_code = 404
+    default_detail = "메시지를 찾을 수 없습니다."
+    default_code = "MESSAGE_NOT_FOUND"
+
+
+class ChatMessageNotSenderException(APIException):
+    status_code = 403
+    default_detail = "메시지 발신자만 삭제할 수 있습니다."
+    default_code = "NOT_MESSAGE_SENDER"

--- a/apps/chat/services.py
+++ b/apps/chat/services.py
@@ -31,3 +31,10 @@ class ChatMessageService:
         )
         # TODO: 메시지 생성 후 관련 로직 추가 (예: 웹소켓으로 브로드캐스트)
         return chat_message
+
+    @staticmethod
+    async def delete_chat_message(message: ChatMessage) -> None:
+        """
+        채팅 메시지를 삭제합니다.
+        """
+        await message.adelete()

--- a/apps/chat/tests/test_chat_consumers.py
+++ b/apps/chat/tests/test_chat_consumers.py
@@ -1,6 +1,7 @@
 # apps/chat/tests/test_chat_consumers.py
 import asyncio
 
+from channels.db import database_sync_to_async  # type: ignore[import-untyped]
 from channels.testing import (  # type: ignore[import-untyped]
     AsgiTestCase,
     WebsocketCommunicator,
@@ -22,7 +23,7 @@ class ChatConsumerTest(AsgiTestCase):  # type: ignore[misc]
 
         async def _async_test_logic() -> None:
             # 1. Create test data: 2 users, 1 study group
-            user1 = await User.objects.acreate_user(  # type: ignore[attr-defined]
+            user1 = await database_sync_to_async(User.objects.create_user)(
                 email="testuser1@example.com",
                 password="password123",
                 nickname="testuser1",
@@ -31,7 +32,7 @@ class ChatConsumerTest(AsgiTestCase):  # type: ignore[misc]
                 gender="M",
                 birthday="2000-01-01",
             )
-            user2 = await User.objects.acreate_user(  # type: ignore[attr-defined]
+            user2 = await database_sync_to_async(User.objects.create_user)(
                 email="testuser2@example.com",
                 password="password123",
                 nickname="testuser2",
@@ -77,11 +78,13 @@ class ChatConsumerTest(AsgiTestCase):  # type: ignore[misc]
             self.assertEqual(response1["type"], "chat.message")
             self.assertEqual(response1["message"], test_message_content)
             self.assertEqual(response1["sender_id"], user1.id)
+            self.assertIn("message_id", response1)
 
             response2 = await communicator2.receive_json_from()
             self.assertEqual(response2["type"], "chat.message")
             self.assertEqual(response2["message"], test_message_content)
             self.assertEqual(response2["sender_id"], user1.id)
+            self.assertIn("message_id", response2)
 
             # 6. Verify the message is saved in the database
             message_exists = await ChatMessage.objects.filter(
@@ -94,5 +97,172 @@ class ChatConsumerTest(AsgiTestCase):  # type: ignore[misc]
             # 7. Disconnect both communicators
             await communicator1.disconnect()
             await communicator2.disconnect()
+
+        asyncio.run(_async_test_logic())
+
+    def test_delete_message_success(self) -> None:
+        """
+        Tests that a message can be successfully deleted by the sender.
+        """
+
+        async def _async_test_logic() -> None:
+            user1 = await database_sync_to_async(User.objects.create_user)(
+                email="testuser1@example.com",
+                password="password123",
+                nickname="testuser1",
+                phone_number="01011111111",
+                name="Test User 1",
+                gender="M",
+                birthday="2000-01-01",
+            )
+            study_group = await StudyGroup.objects.acreate(
+                name="Test Study Group",
+                max_headcount=10,
+                start_at="2025-10-21T10:00:00Z",
+                end_at="2025-11-21T10:00:00Z",
+            )
+            await GroupMember.objects.acreate(study_group=study_group, user=user1, is_leader=True)
+
+            communicator1 = WebsocketCommunicator(
+                ChatConsumer.as_asgi(),
+                f"/ws/study-groups/{study_group.id}/chat/",
+            )
+            communicator1.scope["user"] = user1
+            connected, _ = await communicator1.connect()
+            self.assertTrue(connected)
+
+            # Send initial message
+            initial_content = "Message to be deleted."
+            await communicator1.send_json_to({"type": "chat.message", "content": initial_content})
+            response = await communicator1.receive_json_from()
+            message_id = response["message_id"]
+
+            # Delete message
+            await communicator1.send_json_to({"type": "chat.delete_message", "message_id": message_id})
+            deleted_response = await communicator1.receive_json_from()
+
+            self.assertEqual(deleted_response["type"], "chat.message.deleted")
+            self.assertEqual(deleted_response["message_id"], message_id)
+            self.assertEqual(deleted_response["deleter_id"], user1.id)
+
+            # Verify message is deleted from DB
+            message_exists = await ChatMessage.objects.filter(id=message_id).aexists()
+            self.assertFalse(message_exists)
+
+            await communicator1.disconnect()
+
+        asyncio.run(_async_test_logic())
+
+    def test_delete_message_not_sender(self) -> None:
+        """
+        Tests that a message cannot be deleted by a non-sender.
+        """
+
+        async def _async_test_logic() -> None:
+            user1 = await database_sync_to_async(User.objects.create_user)(
+                email="testuser1@example.com",
+                password="password123",
+                nickname="testuser1",
+                phone_number="01011111111",
+                name="Test User 1",
+                gender="M",
+                birthday="2000-01-01",
+            )
+            user2 = await database_sync_to_async(User.objects.create_user)(
+                email="testuser2@example.com",
+                password="password123",
+                nickname="testuser2",
+                phone_number="01022222222",
+                name="Test User 2",
+                gender="F",
+                birthday="2000-01-02",
+            )
+            study_group = await StudyGroup.objects.acreate(
+                name="Test Study Group",
+                max_headcount=10,
+                start_at="2025-10-21T10:00:00Z",
+                end_at="2025-11-21T10:00:00Z",
+            )
+            await GroupMember.objects.acreate(study_group=study_group, user=user1, is_leader=True)
+            await GroupMember.objects.acreate(study_group=study_group, user=user2)
+
+            communicator1 = WebsocketCommunicator(
+                ChatConsumer.as_asgi(),
+                f"/ws/study-groups/{study_group.id}/chat/",
+            )
+            communicator1.scope["user"] = user1
+            connected1, _ = await communicator1.connect()
+            self.assertTrue(connected1)
+
+            communicator2 = WebsocketCommunicator(
+                ChatConsumer.as_asgi(),
+                f"/ws/study-groups/{study_group.id}/chat/",
+            )
+            communicator2.scope["user"] = user2
+            connected2, _ = await communicator2.connect()
+            self.assertTrue(connected2)
+
+            # User1 sends initial message
+            initial_content = "Message to be deleted."
+            await communicator1.send_json_to({"type": "chat.message", "content": initial_content})
+            response = await communicator1.receive_json_from()
+            message_id = response["message_id"]
+
+            # User2 tries to delete User1's message
+            await communicator2.send_json_to({"type": "chat.delete_message", "message_id": message_id})
+            error_response = await communicator2.receive_json_from()
+
+            self.assertEqual(error_response["type"], "error")
+            self.assertEqual(error_response["code"], "NOT_MESSAGE_SENDER")
+
+            # Verify message in DB is unchanged
+            message_exists = await ChatMessage.objects.filter(id=message_id).aexists()
+            self.assertTrue(message_exists)
+
+            await communicator1.disconnect()
+            await communicator2.disconnect()
+
+        asyncio.run(_async_test_logic())
+
+    def test_delete_message_not_found(self) -> None:
+        """
+        Tests that an error is returned when trying to delete a non-existent message.
+        """
+
+        async def _async_test_logic() -> None:
+            user1 = await database_sync_to_async(User.objects.create_user)(
+                email="testuser1@example.com",
+                password="password123",
+                nickname="testuser1",
+                phone_number="01011111111",
+                name="Test User 1",
+                gender="M",
+                birthday="2000-01-01",
+            )
+            study_group = await StudyGroup.objects.acreate(
+                name="Test Study Group",
+                max_headcount=10,
+                start_at="2025-10-21T10:00:00Z",
+                end_at="2025-11-21T10:00:00Z",
+            )
+            await GroupMember.objects.acreate(study_group=study_group, user=user1, is_leader=True)
+
+            communicator1 = WebsocketCommunicator(
+                ChatConsumer.as_asgi(),
+                f"/ws/study-groups/{study_group.id}/chat/",
+            )
+            communicator1.scope["user"] = user1
+            connected, _ = await communicator1.connect()
+            self.assertTrue(connected)
+
+            # Try to delete a non-existent message
+            non_existent_message_id = 99999
+            await communicator1.send_json_to({"type": "chat.delete_message", "message_id": non_existent_message_id})
+            error_response = await communicator1.receive_json_from()
+
+            self.assertEqual(error_response["type"], "error")
+            self.assertEqual(error_response["code"], "MESSAGE_NOT_FOUND")
+
+            await communicator1.disconnect()
 
         asyncio.run(_async_test_logic())


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #113 
- 작업 요약: ✨ feat: 메세지 삭제 기능 구현 
(하나의 브랜치에서 수정/삭제 기능구현을 했으나 대형 PR을 피하기 위해 각 기능 브랜치 생성 후 작업)

## 📄 상세 내용
- [x] WebSocket 메시지 삭제 기능 구현
- 기능 개요: 
클라이언트가 chat.delete_message 타입의 WebSocket 메시지를 전송하면, 서버는 이를 수신하여 해당 message_id에 해당하는 채팅 메시지를 데이터베이스에서 삭제하고, 이 변경 사항을 채팅방의 모든 참여자에게 실시간으로 브로드캐스트

- `apps/chat/consumers.py` 변경 사항:
       - receive_json 메서드에 chat.delete_message 이벤트 핸들러를 추가하여 클라이언트의 삭제 요청을 처리
       - delete_chat_message 비동기 메서드를 구현하여 메시지 조회 및 발신자 권한 검증 후 ChatMessageService를 호출하여 실제 삭제를 수행하도록 로직을 캡슐화
       - chat_message_deleted 비동기 메서드를 추가하여 메시지 삭제 이벤트를 수신하고, message_id와 deleter_id를 포함한 JSON 데이터를 클라이언트에게 전송하여 UI 업데이트를 지원
       
- `apps/chat/services.py` 변경 사항:
       - ChatMessageService 클래스에 delete_chat_message 정적 비동기 메서드를 추가
       - 이 메서드는 ChatMessage 객체를 인자로 받아 await message.adelete()를 통해 데이터베이스에서 메시지를 비동기적으로 삭제하는 로직을 담당
       
- `apps/chat/exceptions.py` 추가:
       - ChatMessageNotFoundException (HTTP 404) 및 ChatMessageNotSenderException (HTTP 403) 커스텀 예외 클래스를 정의
       - rest_framework.exceptions.APIException을 상속받아 DRF의 표준 예외 처리 흐름을 따르며, 메시지 삭제 실패 시 클라이언트에게 구체적인 오류 응답을 제공
       
- `apps/chat/tests/test_chat_consumers.py` 변경 사항:
       - test_delete_message_success: 메시지 발신자가 자신의 메시지를 성공적으로 삭제하는 시나리오를 테스트
       - 웹소켓 응답 및 DB 조회를 통해 메시지 삭제 여부를 검증
       - test_delete_message_not_sender: 메시지 발신자가 아닌 다른 사용자가 메시지 삭제를 시도할 때 NOT_MESSAGE_SENDER 오류가 올바르게 발생하는지 테스트
       - test_delete_message_not_found: 존재하지 않는 메시지 id로 삭제를 시도할 때 MESSAGE_NOT_FOUND 오류가 발생하는지 테스트
       
- [x] 코드 개선 및 타입 안정성 강화
- `message_id` 전송 개선:
       - 기존 문제점: 메시지 생성 후 클라이언트에게 전송되는 chat.message 이벤트에 생성된 메시지의 고유 id가 포함되지 않아, 클라이언트 측에서 메시지 id를 알기 위해 추가적인 로직(예: DB 조회)이 필요하다고 판단
       - 개선 사항: consumers.py의 receive_json 및 chat_message 메서드를 수정하여 chat.message 이벤트에 생성된 message_id를 포함하도록 변경 (클라이언트의 불필요한 DB 조회 및 복잡한 로직을 방지하고, API의 응답성을 개선)
       - 테스트 반영: test_chat_consumers.py의 test_chat_message_broadcasts_to_all_users_in_group 테스트에 message_id 포함 여부를 검증하는 assertIn 구문을 추가
       
   - 권한 검증 로직 리팩토링:
       - 기존 문제점: delete_chat_message (및 이전 edit_chat_message) 메서드 내에서 '메시지 존재 여부 확인' 및 '발신자 권한 확인' 로직이 중복
       - 개선 사항: ChatConsumer 클래스 내에 _get_message_and_verify_sender라는 비공개 헬퍼 메서드를 새로 생성하여 이 중복 로직을 캡슐화 
       - 이 메서드는 ChatMessage 객체를 반환하거나 적절한 예외
         (Chat Message Not Found Exception, ChatMessageNotSenderException)를 발생 
       - delete_chat_message 메서드는 이 메서드를 호출하여 코드를 더 간결하고 재사용 가능하게 작업
       
   - `mypy` 타입 오류 해결:
       - consumers.py 및 tests/test_chat_consumers.py 파일에서 발생하던 mypy 타입 오류를 해결
       - create_chat_message 메서드의 반환 타입에 typing.cast를 사용하여 no-any-return 오류를 해결
       - delete_chat_message 및 _get_message_and_verify_sender 메서드의 user 파라미터 타입을 AbstractBaseUser에서 apps.users.models.User로 명시하여 attr-defined 오류를 해결
       - channels 라이브러리 관련 import-untyped 오류는 # type: ignore[import-untyped] 주석을 추가하여 처리
       - type channels 라이브러리 활용 고려

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
