### PR TITLE
✨ feat : 채팅방 목록 조회 기능 구현

### DIFF
--- a/apps/chat/pagination.py
+++ b/apps/chat/pagination.py
@@ -1,0 +1,7 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class ChatMessagePagination(PageNumberPagination):
+    page_size = 300
+    page_size_query_param = "page_size"
+    max_page_size = 1000

--- a/apps/chat/serializers.py
+++ b/apps/chat/serializers.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from rest_framework import serializers
+
+from apps.chat.models import ChatMessage
+from apps.users.serializers.user_profile_serializers import UserProfileSerializer
+
+
+class ChatMessageSerializer(serializers.ModelSerializer[ChatMessage]):
+    sender = UserProfileSerializer(read_only=True)
+
+    class Meta:
+        model = ChatMessage
+        fields = ("id", "sender", "content", "created_at")
+
+
+class ChatRoomSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField(help_text="스터디 그룹 ID")
+    name = serializers.CharField(help_text="스터디 그룹명")
+    last_message = serializers.CharField(allow_null=True, help_text="마지막 메시지 내용")
+    unread_count = serializers.IntegerField(default=0, help_text="안 읽은 메시지 수")

--- a/apps/chat/serializers.py
+++ b/apps/chat/serializers.py
@@ -14,8 +14,14 @@ class ChatMessageSerializer(serializers.ModelSerializer[ChatMessage]):
         fields = ("id", "sender", "content", "created_at")
 
 
+class LastMessageSerializer(serializers.Serializer[Any]):
+    content = serializers.CharField(help_text="마지막 메시지 내용")
+    sender_nickname = serializers.CharField(help_text="마지막 메시지 발신자 닉네임")
+    created_at = serializers.DateTimeField(help_text="마지막 메시지 전송 일시")
+
+
 class ChatRoomSerializer(serializers.Serializer[Any]):
     id = serializers.IntegerField(help_text="스터디 그룹 ID")
     name = serializers.CharField(help_text="스터디 그룹명")
-    last_message = serializers.CharField(allow_null=True, help_text="마지막 메시지 내용")
+    last_message = LastMessageSerializer(allow_null=True, help_text="마지막 메시지 정보")
     unread_count = serializers.IntegerField(default=0, help_text="안 읽은 메시지 수")

--- a/apps/chat/services/chat_room_service.py
+++ b/apps/chat/services/chat_room_service.py
@@ -18,7 +18,13 @@ class ChatRoomService:
 
         # 각 그룹의 마지막 메시지 서브쿼리
         last_message_subquery = (
-            ChatMessage.objects.filter(study_group_id=OuterRef("pk")).order_by("-created_at").values("content")[:1]
+            ChatMessage.objects.filter(study_group_id=OuterRef("pk"))
+            .order_by("-created_at")
+            .values(
+                "content",
+                "sender__nickname",
+                "created_at",
+            )[:1]
         )
 
         # 사용자의 마지막 읽은 메시지 ID 서브쿼리 (존재하지 않을 경우를 대비)
@@ -39,8 +45,17 @@ class ChatRoomService:
 
         # 스터디 그룹 정보와 함께 마지막 메시지, 안 읽은 메시지 수 조합
         chat_rooms = study_groups.annotate(
-            last_message=Subquery(last_message_subquery),
+            last_message_content=Subquery(last_message_subquery.values("content")),
+            last_message_sender_nickname=Subquery(last_message_subquery.values("sender__nickname")),
+            last_message_created_at=Subquery(last_message_subquery.values("created_at")),
             unread_count=Coalesce(Subquery(unread_count_subquery, output_field=models.IntegerField()), 0),
-        ).values("id", "name", "last_message", "unread_count")
+        ).values(
+            "id",
+            "name",
+            "last_message_content",
+            "last_message_sender_nickname",
+            "last_message_created_at",
+            "unread_count",
+        )
 
         return chat_rooms

--- a/apps/chat/services/chat_room_service.py
+++ b/apps/chat/services/chat_room_service.py
@@ -1,0 +1,46 @@
+from typing import Any, Dict, Iterable
+
+from django.contrib.auth import get_user_model
+from django.db import models
+from django.db.models import Count, OuterRef, Subquery
+from django.db.models.functions import Coalesce
+
+from apps.chat.models import ChatMessage, LastReadMessage
+from apps.studies.models.groups import StudyGroup
+from apps.users.models import User
+
+
+class ChatRoomService:
+    @staticmethod
+    def get_chat_rooms_for_user(user: User) -> Iterable[Dict[str, Any]]:
+        # 사용자가 속한 스터디 그룹 목록 조회
+        study_groups = StudyGroup.objects.filter(members__user=user)
+
+        # 각 그룹의 마지막 메시지 서브쿼리
+        last_message_subquery = (
+            ChatMessage.objects.filter(study_group_id=OuterRef("pk")).order_by("-created_at").values("content")[:1]
+        )
+
+        # 사용자의 마지막 읽은 메시지 ID 서브쿼리 (존재하지 않을 경우를 대비)
+        last_read_message_id_subquery = LastReadMessage.objects.filter(study_group_id=OuterRef("pk"), user=user).values(
+            "message_id"
+        )
+
+        # 안 읽은 메시지 수 계산 서브쿼리
+        unread_count_subquery = (
+            ChatMessage.objects.filter(
+                study_group_id=OuterRef("pk"),
+                id__gt=Coalesce(Subquery(last_read_message_id_subquery), 0),
+            )
+            .values("study_group_id")
+            .annotate(count=Count("id"))
+            .values("count")
+        )
+
+        # 스터디 그룹 정보와 함께 마지막 메시지, 안 읽은 메시지 수 조합
+        chat_rooms = study_groups.annotate(
+            last_message=Subquery(last_message_subquery),
+            unread_count=Coalesce(Subquery(unread_count_subquery, output_field=models.IntegerField()), 0),
+        ).values("id", "name", "last_message", "unread_count")
+
+        return chat_rooms

--- a/apps/chat/tests/test_chat_room_api.py
+++ b/apps/chat/tests/test_chat_room_api.py
@@ -48,7 +48,11 @@ class ChatRoomAPITestCase(APITestCase):
         room3_data = next((r for r in response.data if r["name"] == "Test Group 3"), None)
 
         assert room1_data is not None
-        self.assertEqual(room1_data["last_message"], self.msg3.content)
+        assert room1_data["last_message"] is not None
+        self.assertEqual(room1_data["last_message"]["content"], self.msg3.content)
+        assert self.msg3.sender is not None  # mypy: sender can be None
+        self.assertEqual(room1_data["last_message"]["sender_nickname"], self.msg3.sender.nickname)
+        self.assertIsNotNone(room1_data["last_message"]["created_at"])
 
     def test_get_chat_room_list_unauthenticated(self) -> None:
         """채팅방 목록 조회 API 비인증 유저 테스트"""

--- a/apps/chat/tests/test_chat_room_api.py
+++ b/apps/chat/tests/test_chat_room_api.py
@@ -1,0 +1,101 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.chat.models import ChatMessage, LastReadMessage
+from apps.studies.models.groups import GroupMember, StudyGroup
+
+User = get_user_model()
+
+
+class ChatRoomAPITestCase(APITestCase):
+    def setUp(self) -> None:
+        self.user1 = User.objects.create_user(email="user1@test.com", password="password123", nickname="user1")
+        self.user2 = User.objects.create_user(email="user2@test.com", password="password123", nickname="user2")
+
+        # Case 1: user1, user2가 속한 그룹 (메시지 3개)
+        self.study_group1 = StudyGroup.objects.create(name="Test Group 1")
+        GroupMember.objects.create(study_group=self.study_group1, user=self.user1, is_leader=True)
+        GroupMember.objects.create(study_group=self.study_group1, user=self.user2)
+        self.msg1 = ChatMessage.objects.create(study_group=self.study_group1, sender=self.user1, content="Hello")
+        self.msg2 = ChatMessage.objects.create(study_group=self.study_group1, sender=self.user2, content="Hi")
+        self.msg3 = ChatMessage.objects.create(study_group=self.study_group1, sender=self.user1, content="Test")
+
+        # Case 2: user1만 속한 그룹 (메시지 없음)
+        self.study_group2 = StudyGroup.objects.create(name="Test Group 2")
+        GroupMember.objects.create(study_group=self.study_group2, user=self.user1, is_leader=True)
+
+        # Case 3: user1이 속한 또 다른 그룹 (메시지 2개)
+        self.study_group3 = StudyGroup.objects.create(name="Test Group 3")
+        GroupMember.objects.create(study_group=self.study_group3, user=self.user1, is_leader=True)
+        self.msg4 = ChatMessage.objects.create(study_group=self.study_group3, sender=self.user1, content="First")
+        self.msg5 = ChatMessage.objects.create(study_group=self.study_group3, sender=self.user1, content="Second")
+
+        self.client.force_authenticate(user=self.user1)
+
+    def test_get_chat_room_list_success(self) -> None:
+        """채팅방 목록 조회 API 성공 테스트"""
+        url = reverse("v1:chat:room-list")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 3)  # user1은 3개의 그룹에 속해 있음
+
+        # 응답 순서는 생성 역순일 수 있으므로 이름으로 찾아서 확인
+        room1_data = next((r for r in response.data if r["name"] == "Test Group 1"), None)
+        room2_data = next((r for r in response.data if r["name"] == "Test Group 2"), None)
+        room3_data = next((r for r in response.data if r["name"] == "Test Group 3"), None)
+
+        assert room1_data is not None
+        self.assertEqual(room1_data["last_message"], self.msg3.content)
+
+    def test_get_chat_room_list_unauthenticated(self) -> None:
+        """채팅방 목록 조회 API 비인증 유저 테스트"""
+        self.client.logout()
+        url = reverse("v1:chat:room-list")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_room_with_no_messages(self) -> None:
+        """메시지가 없는 채팅방의 last_message는 null이어야 함"""
+        url = reverse("v1:chat:room-list")
+        response = self.client.get(url)
+        room2_data = next((r for r in response.data if r["name"] == "Test Group 2"), None)
+
+        assert room2_data is not None
+        self.assertIsNone(room2_data["last_message"])
+
+    def test_unread_count_with_no_read_history(self) -> None:
+        """읽은 기록이 없을 때, 모든 메시지가 안 읽은 것으로 계산되어야 함"""
+        url = reverse("v1:chat:room-list")
+        response = self.client.get(url)
+        room1_data = next((r for r in response.data if r["name"] == "Test Group 1"), None)
+
+        assert room1_data is not None
+        self.assertEqual(room1_data["unread_count"], 3)
+
+    def test_unread_count_with_some_messages_read(self) -> None:
+        """일부 메시지를 읽었을 때, 안 읽은 메시지 수가 정확해야 함"""
+        # user1이 group1에서 msg2까지 읽음
+        LastReadMessage.objects.create(study_group=self.study_group1, user=self.user1, message=self.msg2)
+
+        url = reverse("v1:chat:room-list")
+        response = self.client.get(url)
+        room1_data = next((r for r in response.data if r["name"] == "Test Group 1"), None)
+
+        assert room1_data is not None
+        self.assertEqual(room1_data["unread_count"], 1)  # msg3만 안 읽음
+
+    def test_unread_count_with_all_messages_read(self) -> None:
+        """모든 메시지를 읽었을 때, 안 읽은 메시지 수는 0이어야 함"""
+        # user1이 group1에서 msg3(마지막)까지 읽음
+        LastReadMessage.objects.create(study_group=self.study_group1, user=self.user1, message=self.msg3)
+
+        url = reverse("v1:chat:room-list")
+        response = self.client.get(url)
+        room1_data = next((r for r in response.data if r["name"] == "Test Group 1"), None)
+
+        assert room1_data is not None
+        self.assertEqual(room1_data["unread_count"], 0)

--- a/apps/chat/urls.py
+++ b/apps/chat/urls.py
@@ -1,6 +1,11 @@
 # apps/chat/urls.py
 from django.urls import URLPattern, URLResolver, path
 
-urlpatterns: list[URLPattern | URLResolver] = [
-    # chat-related URLs will be added here.
+from apps.chat.views import ChatMessageListView, ChatRoomListView
+
+app_name = "chat"
+
+urlpatterns = [
+    path("study-groups/<int:study_group_id>/messages", ChatMessageListView.as_view(), name="message-list"),
+    path("rooms", ChatRoomListView.as_view(), name="room-list"),
 ]

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -1,0 +1,139 @@
+from typing import Any, List, cast
+
+from django.contrib.auth import get_user_model
+from django.db.models.query import QuerySet
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import status
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.chat.models import ChatMessage
+from apps.chat.pagination import ChatMessagePagination
+from apps.chat.serializers import ChatMessageSerializer, ChatRoomSerializer
+from apps.chat.services.chat_room_service import ChatRoomService
+from apps.studies.models.groups import GroupMember
+from apps.users.models import User
+
+
+class ChatMessageListView(ListAPIView[ChatMessage]):
+    serializer_class = ChatMessageSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = ChatMessagePagination
+
+    def get_queryset(self) -> QuerySet[ChatMessage]:
+        study_group_id = self.kwargs["study_group_id"]
+        return ChatMessage.objects.filter(study_group_id=study_group_id).order_by("-created_at")
+
+    @extend_schema(
+        tags=["Chat"],
+        summary="메시지 목록 조회 API",
+        description="""
+        특정 그룹의 메시지 목록을 페이지네이션으로 조회합니다.
+        로그인한 사용자는 해당 스터디 그룹의 멤버여야 합니다.
+        """,
+        parameters=[
+            OpenApiParameter(
+                name="study_group_id",
+                type=int,
+                location=OpenApiParameter.PATH,
+                description="그룹 ID",
+                required=True,
+            ),
+            OpenApiParameter(
+                name="page",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                description="페이지 번호 (기본값 1)",
+                required=False,
+            ),
+            OpenApiParameter(
+                name="page_size",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                description="페이지당 개수 (기본값 20)",
+                required=False,
+            ),
+        ],
+        responses={
+            status.HTTP_200_OK: {
+                "type": "object",
+                "properties": {
+                    "status": {"type": "string", "example": "success"},
+                    "code": {"type": "string", "example": "SUCCESS"},
+                    "message": {"type": "string", "example": "메시지 목록 조회 성공"},
+                    "data": {
+                        "type": "object",
+                        "properties": {
+                            "messages": {
+                                "type": "array",
+                                "items": ChatMessageSerializer,
+                            },
+                            "pagination": {
+                                "type": "object",
+                                "properties": {
+                                    "page": {"type": "integer"},
+                                    "page_size": {"type": "integer"},
+                                    "total_count": {"type": "integer"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            status.HTTP_403_FORBIDDEN: {
+                "type": "object",
+                "properties": {
+                    "status": {"type": "string", "example": "error"},
+                    "code": {"type": "string", "example": "NOT_A_MEMBER"},
+                    "message": {"type": "string", "example": "해당 사용자는 스터디 그룹 멤버가 아닙니다."},
+                    "data": {"type": "string", "nullable": True, "example": None},
+                },
+            },
+        },
+    )
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        study_group_id = self.kwargs["study_group_id"]
+        user = request.user
+
+        # 사용자가 스터디 그룹의 멤버인지 확인
+        if (
+            not user.is_authenticated
+            or not GroupMember.objects.filter(study_group_id=study_group_id, user=user).exists()
+        ):
+            return Response(
+                {
+                    "status": "error",
+                    "code": "NOT_A_MEMBER",
+                    "message": "해당 사용자는 스터디 그룹 멤버가 아닙니다.",
+                    "data": None,
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        queryset = self.get_queryset()
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
+
+class ChatRoomListView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=["Chat"],
+        summary="채팅방 목록 조회 API",
+        description="사용자가 속한 모든 채팅방의 목록과 각 방의 마지막 메시지, 안 읽은 메시지 수를 조회합니다.",
+        responses=ChatRoomSerializer(many=True),
+    )
+    def get(self, request: Request) -> Response:
+        user = cast(User, request.user)
+        chat_rooms_data = list(ChatRoomService.get_chat_rooms_for_user(user))
+        serializer = ChatRoomSerializer(chat_rooms_data, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #119 
- 작업 요약: 채팅방 목록 조회 기능 구현 
(이전 완료된 작업이었으나 우선순위 판단 미스로 인해 웹소켓 메시지 수정/삭제 기능 구현을 진행 -> 피드백 받은 후 수정/보완하여 PR요청)

## 📄 상세 내용
- [x] 채팅방 목록 조회 API 구현:
- 사용자가 속한 모든 채팅방의 목록을 조회하는 API(GET /api/v1/chat/rooms)를 구현
- 각 채팅방 정보에는 스터디 그룹 ID, 그룹명, 마지막 메시지, 안 읽은 메시지 수가 포함

- ChatRoomService 추가 (apps/chat/services/chat_room_service.py)
- 채팅방 목록 조회를 위한 비즈니스 로직을 서비스 계층으로 분리
- ORM의 annotate, Subquery 기능을 활용하여, 각 채팅방의 마지막 메시지와 안 읽은 메시지 수를 단일 쿼리셋으로 효율적 계산
   이를 통해 N+1 문제를 방지
- Coalesce 함수를 사용하여, 사용자의 읽은 기록이 없는 케이스에서도 unread_count가 null이 아닌 0으로 반환되도록 안정성 높힘

- ChatRoomSerializer 및 ChatRoomListView 추가
- 서비스 계층에서 처리된 데이터를 API 응답 형식에 맞게 직렬화하는 ChatRoomSerializer를 추가
- ChatRoomListView를 구현하여 API 요청을 처리하고, Spec 문서를 extend_schema로 상세히 작성

- [x] 테스트 코드 강화 (apps/chat/tests/test_chat_room_api.py)
- 기본적인 API 성공 및 인증 실패 테스트 외에, 다음과 같은 다양한 엣지 케이스를 검증하는 테스트 코드를 추가
- 채팅방에 메시지가 하나도 없는 경우
- 사용자가 아직 읽은 메시지가 하나도 없는 경우
- 사용자가 일부 메시지만 읽은 경우
- 사용자가 모든 메시지를 읽은 경우

- [x] mypy 타입 에러 해결
- 신규로 작성된 모든 코드에 대해 mypy 타입 검사를 통과하도록 수정하여 코드의 안정성과 유지보수성을 향상

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
