### PR TITLE
chore: api 명세서 응답 부분 맞게끔 수정, 권한변경 admin만 가능하게 수정

### DIFF
--- a/apps/users/serializers/admin_users_serializer.py
+++ b/apps/users/serializers/admin_users_serializer.py
@@ -11,9 +11,7 @@ from apps.users.validators import validate_korean_phone
 # [관리자] 회원 목록 조회
 class AdminUserListSerializer(serializers.ModelSerializer[User]):
 
-    role = serializers.ChoiceField(choices=Role.choices, read_only=True)
     withdrawal_requested_at = serializers.DateTimeField(read_only=True, allow_null=True)
-    status = serializers.ChoiceField(choices=UserStatus.choices, read_only=True)
 
     class Meta:
         model = User
@@ -23,8 +21,9 @@ class AdminUserListSerializer(serializers.ModelSerializer[User]):
             "nickname",
             "name",
             "birthday",
-            "status",
-            "role",
+            "is_active",
+            "is_superuser",
+            "is_staff",
             "created_at",
             "withdrawal_requested_at",
         ]

--- a/apps/users/tests/test_admin_users_view.py
+++ b/apps/users/tests/test_admin_users_view.py
@@ -1,21 +1,22 @@
-from __future__ import annotations
-
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from apps.users.enums import UserStatus
 from apps.users.models import User, Withdrawal
+from apps.users.enums import UserStatus
 
 
 class TestAdminUserAPI(APITestCase):
+    """관리자 전용 회원 관리 API 테스트"""
+
     admin: User
     user: User
     client: APIClient
 
     @classmethod
     def setUpTestData(cls) -> None:
+        """테스트용 기본 데이터 생성"""
         cls.admin = User.objects.create_superuser(
             email="admin@example.com",
             password="1234",
@@ -36,6 +37,7 @@ class TestAdminUserAPI(APITestCase):
         )
 
     def setUp(self) -> None:
+        """요청 전 기본 관리자 인증"""
         self.client = APIClient()
         self.client.force_authenticate(user=self.admin)
 
@@ -43,17 +45,20 @@ class TestAdminUserAPI(APITestCase):
     def test_user_list(self) -> None:
         url = reverse("admin_users:admin-user-list")
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("email", response.data[0])
 
-    # ✅ 회원 상세 조회 / 정보 수정 / 삭제 (통합 뷰)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        users = response.data["data"]["users"]
+        self.assertTrue(len(users) > 0)
+        self.assertIn("email", users[0])
+
+    # ✅ 회원 상세 조회 / 수정 / 삭제
     def test_user_detail_update_delete(self) -> None:
         url = reverse("admin_users:admin-user-detail", args=[self.user.id])
 
         # 상세 조회
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["email"], self.user.email)
+        self.assertEqual(response.data["data"]["email"], self.user.email)
 
         # 정보 수정
         payload_name = {"name": "수정된유저"}
@@ -66,26 +71,19 @@ class TestAdminUserAPI(APITestCase):
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    # ✅ 회원 권한 변경 (별도 엔드포인트)
-    def test_change_user_role(self) -> None:
-        url = reverse("admin_users:admin-user-role-update", args=[self.user.id])
-        payload_role = {"role": "staff"}
-        response = self.client.patch(url, payload_role, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.user.refresh_from_db()
-        self.assertTrue(self.user.is_staff)
+    # 🚫 스태프는 권한 변경 불가
+    def test_change_user_role_superuser_only(self) -> None:
+        target = User.objects.create_user(
+            email="target@example.com",
+            password="1234",
+            name="일반유저",
+            nickname="target",
+            phone_number="01055556666",
+            gender="female",
+            birthday="1995-05-05",
+        )
 
-    # ✅ 유저 상태 필드 (탈퇴 예정)
-    def test_user_status_field(self) -> None:
-        Withdrawal.objects.create(user=self.user, due_date=timezone.now())
-        url = reverse("admin_users:admin-user-detail", args=[self.user.id])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["status"], UserStatus.WITHDRAWAL_PENDING.value)
-
-    # 🚫 스태프 권한으로 삭제 시도 (권한 없음)
-    def test_staff_cannot_delete_user(self) -> None:
-        staff_user = User.objects.create_user(
+        staff = User.objects.create_user(
             email="staff@example.com",
             password="1234",
             name="스태프유저",
@@ -95,18 +93,45 @@ class TestAdminUserAPI(APITestCase):
             birthday="1991-03-03",
             is_staff=True,
         )
+        self.client.force_authenticate(user=staff)
 
-        target_user = User.objects.create_user(
-            email="target@example.com",
-            password="1234",
-            name="삭제대상",
-            nickname="target",
-            phone_number="01044445555",
-            gender="female",
-            birthday="1995-05-05",
-        )
+        url = reverse("admin_users:admin-user-role-update", args=[target.id])
+        payload = {"role": "admin"}
+        response = self.client.patch(url, payload, format="json")
 
-        self.client.force_authenticate(user=staff_user)
-        url = reverse("admin_users:admin-user-detail", args=[target_user.id])
-        response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        target.refresh_from_db()
+        self.assertFalse(target.is_superuser)
+        self.assertFalse(target.is_staff)
+
+    # ✅ 탈퇴 예정 상태 필드 확인
+    def test_user_status_field(self) -> None:
+        Withdrawal.objects.create(user=self.user, due_date=timezone.now())
+        url = reverse("admin_users:admin-user-detail", args=[self.user.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data["data"]
+        self.assertIn("is_active", data)
+        self.assertIn("status", data)
+        self.assertEqual(data["status"], UserStatus.WITHDRAWAL_PENDING.value)
+
+    # ⚠️ 예외 케이스 - 존재하지 않는 유저 상세조회
+    def test_user_detail_not_found(self) -> None:
+        url = reverse("admin_users:admin-user-detail", args=[999999])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("회원 정보를 찾을 수 없습니다.", response.data["error"])
+
+    # ⚠️ 예외 케이스 - 존재하지 않는 유저 삭제
+    def test_delete_user_not_found(self) -> None:
+        url = reverse("admin_users:admin-user-detail", args=[999999])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # ⚠️ 예외 케이스 - 잘못된 role 입력
+    def test_change_user_role_invalid_role(self) -> None:
+        url = reverse("admin_users:admin-user-role-update", args=[self.user.id])
+        payload = {"role": "INVALID_ROLE"}
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/apps/users/tests/test_admin_users_view.py
+++ b/apps/users/tests/test_admin_users_view.py
@@ -3,8 +3,8 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from apps.users.models import User, Withdrawal
 from apps.users.enums import UserStatus
+from apps.users.models import User, Withdrawal
 
 
 class TestAdminUserAPI(APITestCase):

--- a/apps/users/views/admin_users_views.py
+++ b/apps/users/views/admin_users_views.py
@@ -33,7 +33,13 @@ class AdminUserListView(APIView):
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         users = AdminUserService.get_user_list()
         serializer = AdminUserListSerializer(users, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(
+            {
+                "detail": "회원 목록 조회에 성공하였습니다.",
+                "data": {"users": serializer.data},
+            },
+            status=status.HTTP_200_OK,
+        )
 
 
 # 관리자 - 회원 상세 조회, 회원 정보 수정, 회원 정보 삭제
@@ -66,7 +72,13 @@ class AdminUserView(APIView):
             return Response({"error": "회원 정보를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
 
         serializer = AdminUserDetailSerializer(user)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(
+            {
+                "detail": "회원 상세 정보를 조회했습니다.",
+                "data": serializer.data,
+            },
+            status=status.HTTP_200_OK,
+        )
 
     def patch(self, request: Request, user_id: int) -> Response:
         # 회원 정보 수정
@@ -75,7 +87,13 @@ class AdminUserView(APIView):
         serializer.is_valid(raise_exception=True)
         updated_user = AdminUserService.update_user_info(user, serializer.validated_data)
         response_data = AdminUserDetailSerializer(updated_user).data
-        return Response(response_data, status=status.HTTP_200_OK)
+        return Response(
+            {
+                "detail": "회원 정보가 수정되었습니다.",
+                "data": response_data,
+            },
+            status=status.HTTP_200_OK,
+        )
 
     def delete(self, request: Request, user_id: int) -> Response:
         # 회원 정보 삭제
@@ -85,10 +103,16 @@ class AdminUserView(APIView):
         try:
             user = AdminUserService.get_user(user_id)
         except Http404:
-            return Response({"error": "회원 정보를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"error": "회원 정보를 찾을 수 없습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         AdminUserService.delete_user(user)
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        return Response(
+            {"detail": "회원이 삭제되었습니다."},
+            status=status.HTTP_204_NO_CONTENT,
+        )
 
 
 # 관리자: 회원 권한(role) 변경
@@ -103,6 +127,10 @@ class AdminUserRoleUpdateView(APIView):
     permission_classes = [IsAdminUser]
 
     def patch(self, request: Request, user_id: int, *args: Any, **kwargs: Any) -> Response:
+
+        if not request.user.is_superuser:
+            raise PermissionDenied("슈퍼유저만 회원 권한을 변경할 수 있습니다.")
+
         serializer = AdminUserRoleUpdateRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
@@ -113,7 +141,7 @@ class AdminUserRoleUpdateView(APIView):
         response_serializer = AdminUserRoleUpdateResponseSerializer(updated_user)
         return Response(
             {
-                "error": "회원 권한이 변경되었습니다.",
+                "detail": "회원 권한이 변경되었습니다.",
                 "data": response_serializer.data,
             },
             status=status.HTTP_200_OK,

--- a/apps/users/views/admin_users_views.py
+++ b/apps/users/views/admin_users_views.py
@@ -98,7 +98,7 @@ class AdminUserView(APIView):
     def delete(self, request: Request, user_id: int) -> Response:
         # 회원 정보 삭제
         if not request.user.is_superuser:
-            raise PermissionDenied("슈퍼유저만 회원을 삭제할 수 있습니다.")
+            raise PermissionDenied("관리자만 회원을 삭제할 수 있습니다.")
 
         try:
             user = AdminUserService.get_user(user_id)
@@ -129,7 +129,7 @@ class AdminUserRoleUpdateView(APIView):
     def patch(self, request: Request, user_id: int, *args: Any, **kwargs: Any) -> Response:
 
         if not request.user.is_superuser:
-            raise PermissionDenied("슈퍼유저만 회원 권한을 변경할 수 있습니다.")
+            raise PermissionDenied("관리자만 회원 권한을 변경할 수 있습니다.")
 
         serializer = AdminUserRoleUpdateRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: api 요청 응답 수정, 권한 변경 admin만 되게 수정

## 📄 상세 내용
- [x] api 응답값 수정 (목록 조회 시 상태, 권한 부분 노출 안 되는 부분 수정, detali 노출 안 되는 부분 수정)
- [x] 권한 변경이 staff도 되는 부분 admin만 가능하게 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
