### PR TITLE
✨ feat : 메시지 내역 조회 API 구현 (테스트 코드 보강 때문에 대형 PR이 될 가능성이 높아 나눠서 PR 요청 하겠습니다.)

### DIFF
--- a/apps/chat/consumers.py
+++ b/apps/chat/consumers.py
@@ -10,7 +10,7 @@ from channels.generic.websocket import (  # type: ignore[import-untyped]
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser
 
-from apps.chat.models import ChatMessage, LastReadMessage
+
 from apps.studies.models.groups import GroupMember, StudyGroup
 
 from .services import ChatMessageService
@@ -32,24 +32,6 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
         # Join room group
         await self.channel_layer.group_add(self.room_group_name, self.channel_name)
         await self.accept()
-
-        # '읽음 처리' 로직 구현
-        if user.is_authenticated:
-            try:
-                latest_message = (
-                    await ChatMessage.objects.filter(study_group_id=self.study_group_id)
-                    .order_by("-created_at")
-                    .afirst()
-                )
-
-                if latest_message:
-                    await LastReadMessage.objects.aupdate_or_create(
-                        user=user,
-                        study_group_id=self.study_group_id,
-                        defaults={"message": latest_message},
-                    )
-            except ChatMessage.DoesNotExist:
-                pass
 
     async def disconnect(self, close_code: int) -> None:
         # Leave room group

--- a/apps/chat/consumers.py
+++ b/apps/chat/consumers.py
@@ -10,7 +10,6 @@ from channels.generic.websocket import (  # type: ignore[import-untyped]
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser
 
-
 from apps.studies.models.groups import GroupMember, StudyGroup
 
 from .services import ChatMessageService

--- a/apps/chat/consumers.py
+++ b/apps/chat/consumers.py
@@ -1,18 +1,18 @@
 # apps/chat/consumers.py
 
 import json
-from typing import Any
+from typing import Any, cast
 
-from channels.db import database_sync_to_async  # type: ignore[import-untyped]
-from channels.generic.websocket import (  # type: ignore[import-untyped]
+from channels.db import database_sync_to_async
+from channels.generic.websocket import (
     AsyncJsonWebsocketConsumer,
 )
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser
 
+from apps.chat.models import ChatMessage
 from apps.studies.models.groups import GroupMember, StudyGroup
-
-from .services import ChatMessageService
+from apps.users.models.user import User
 
 
 class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
@@ -70,8 +70,8 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
         Asynchronously creates a chat message in the database.
         """
         study_group = await StudyGroup.objects.aget(id=self.study_group_id)
-        await database_sync_to_async(ChatMessageService.create_chat_message)(
-            sender=user,
+        await ChatMessage.objects.acreate(
+            sender=cast(User, user),
             study_group=study_group,
             content=content,
         )

--- a/apps/chat/pagination.py
+++ b/apps/chat/pagination.py
@@ -1,4 +1,7 @@
+from typing import Any, Optional
+
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.request import Request
 
 
 class ChatMessagePagination(PageNumberPagination):
@@ -6,9 +9,9 @@ class ChatMessagePagination(PageNumberPagination):
     page_size_query_param = "page_size"
     max_page_size = 1000
 
-    def paginate_queryset(self, queryset, request, view=None):
+    def paginate_queryset(self, queryset: Any, request: Request, view: Optional[Any] = None) -> Optional[list[Any]]:
         # 첫 페이지인 경우 300개의 메시지를 반환
-        if self.request.query_params.get(self.page_query_param, "1") == "1":
+        if request.query_params.get(self.page_query_param, "1") == "1":
             self.page_size = 300
         else:
             self.page_size = 100

--- a/apps/chat/pagination.py
+++ b/apps/chat/pagination.py
@@ -2,6 +2,14 @@ from rest_framework.pagination import PageNumberPagination
 
 
 class ChatMessagePagination(PageNumberPagination):
-    page_size = 300
+    page_size = 100  # 기본 페이지 크기
     page_size_query_param = "page_size"
     max_page_size = 1000
+
+    def paginate_queryset(self, queryset, request, view=None):
+        # 첫 페이지인 경우 300개의 메시지를 반환
+        if self.request.query_params.get(self.page_query_param, "1") == "1":
+            self.page_size = 300
+        else:
+            self.page_size = 100
+        return super().paginate_queryset(queryset, request, view)

--- a/apps/chat/serializers.py
+++ b/apps/chat/serializers.py
@@ -7,7 +7,7 @@ from apps.users.models import User
 from apps.users.serializers.user_profile_serializers import UserProfileSerializer
 
 
-class ChatMessageSerializer(serializers.ModelSerializer):
+class ChatMessageSerializer(serializers.ModelSerializer[ChatMessage]):
     sender_id = serializers.IntegerField(source="sender.id", read_only=True)
     sender_nickname = serializers.CharField(source="sender.nickname", read_only=True)
     study_group_id = serializers.IntegerField(source="study_group.id", read_only=True)

--- a/apps/chat/serializers.py
+++ b/apps/chat/serializers.py
@@ -2,16 +2,46 @@ from typing import Any
 
 from rest_framework import serializers
 
-from apps.chat.models import ChatMessage
+from apps.chat.models import ChatMessage, LastReadMessage
+from apps.users.models import User
 from apps.users.serializers.user_profile_serializers import UserProfileSerializer
 
 
-class ChatMessageSerializer(serializers.ModelSerializer[ChatMessage]):
-    sender = UserProfileSerializer(read_only=True)
+class ChatMessageSerializer(serializers.ModelSerializer):
+    sender_id = serializers.IntegerField(source="sender.id", read_only=True)
+    sender_nickname = serializers.CharField(source="sender.nickname", read_only=True)
+    study_group_id = serializers.IntegerField(source="study_group.id", read_only=True)
+    file_url = serializers.SerializerMethodField()
+    is_read = serializers.SerializerMethodField()
 
     class Meta:
         model = ChatMessage
-        fields = ("id", "sender", "content", "created_at")
+        fields = [
+            "id",
+            "sender_id",
+            "sender_nickname",
+            "study_group_id",
+            "content",
+            "file_url",
+            "is_read",
+            "created_at",
+        ]
+
+    def get_file_url(self, obj: ChatMessage) -> None:
+        # ChatMessage 모델에 file_url 필드가 없으므로 항상 None을 반환합니다.
+        # 파일 메시지 전송 기능이 추가되면 이 부분을 수정해야 합니다.
+        return None
+
+    def get_is_read(self, obj: ChatMessage) -> bool:
+        request = self.context.get("request")
+        if not request or not request.user.is_authenticated:
+            return False  # Unauthenticated users cannot have read status
+
+        try:
+            last_read_message = LastReadMessage.objects.get(user=request.user, study_group=obj.study_group)
+            return obj.id <= last_read_message.message.id
+        except LastReadMessage.DoesNotExist:
+            return False  # No last read message for this user in this group
 
 
 class LastMessageSerializer(serializers.Serializer[Any]):

--- a/apps/chat/tests/test_chat_api.py
+++ b/apps/chat/tests/test_chat_api.py
@@ -1,0 +1,125 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.chat.models import ChatMessage, LastReadMessage
+from apps.studies.models import StudyGroup
+from apps.studies.models.groups import GroupMember
+
+User = get_user_model()
+
+
+class ChatMessageListAPIViewTest(APITestCase):
+    def setUp(self) -> None:
+        self.user1 = User.objects.create_user(
+            email="user1@example.com",
+            password="password123",
+            nickname="user1",
+            phone_number="01011112222",
+            name="User One",
+            gender="M",
+            birthday="2000-01-01",
+        )
+        self.user2 = User.objects.create_user(
+            email="user2@example.com",
+            password="password123",
+            nickname="user2",
+            phone_number="01033334444",
+            name="User Two",
+            gender="F",
+            birthday="2000-01-02",
+        )
+        self.study_group = StudyGroup.objects.create(
+            name="Test Study Group",
+            max_headcount=10,
+            start_at="2025-01-01T00:00:00Z",
+            end_at="2025-12-31T23:59:59Z",
+        )
+        self.group_member1 = GroupMember.objects.create(
+            user=self.user1, study_group=self.study_group, is_leader=True
+        )
+        self.group_member2 = GroupMember.objects.create(
+            user=self.user2, study_group=self.study_group
+        )
+
+        # Create 350 messages for pagination testing
+        for i in range(1, 351):
+            ChatMessage.objects.create(
+                sender=self.user1,
+                study_group=self.study_group,
+                content=f"Message {i}",
+            )
+
+        self.url = reverse(
+            "chat:message-list", kwargs={"study_group_id": self.study_group.id}
+        )
+
+    def test_message_list_unauthenticated(self) -> None:
+        """인증되지 않은 사용자는 메시지 목록을 조회할 수 없습니다."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_message_list_not_group_member(self) -> None:
+        """스터디 그룹 멤버가 아닌 사용자는 메시지 목록을 조회할 수 없습니다."""
+        non_member = User.objects.create_user(
+            email="nonmember@example.com",
+            password="password123",
+            nickname="nonmember",
+            phone_number="01055556666",
+            name="Non Member",
+            gender="M",
+            birthday="2000-01-03",
+        )
+        self.client.force_authenticate(user=non_member)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_message_list_success_first_page_300_messages(self) -> None:
+        """첫 페이지 요청 시 300개의 메시지를 반환합니다."""
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]["messages"]), 300)
+        self.assertEqual(response.data["data"]["pagination"]["page"], 1)
+        self.assertEqual(response.data["data"]["pagination"]["page_size"], 300)
+        self.assertEqual(response.data["data"]["pagination"]["total_count"], 350)
+
+    def test_message_list_success_second_page_100_messages(self) -> None:
+        """두 번째 페이지 요청 시 100개의 메시지를 반환합니다."""
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.get(self.url + "?page=2")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]["messages"]), 50)  # Remaining 50 messages
+        self.assertEqual(response.data["data"]["pagination"]["page"], 2)
+        self.assertEqual(response.data["data"]["pagination"]["page_size"], 100)
+        self.assertEqual(response.data["data"]["pagination"]["total_count"], 350)
+
+    def test_message_list_is_read_status(self) -> None:
+        """메시지 읽음 상태를 올바르게 반환합니다."""
+        # user1이 메시지 300까지 읽었다고 가정
+        last_read_message = ChatMessage.objects.get(content="Message 300")
+        LastReadMessage.objects.create(
+            user=self.user1, study_group=self.study_group, message=last_read_message
+        )
+
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        messages = response.data["data"]["messages"]
+        # 메시지 300까지는 is_read가 True여야 함
+        for msg in messages:
+            if int(msg["content"].split()[-1]) <= 300:
+                self.assertTrue(msg["is_read"])
+            else:
+                self.assertFalse(msg["is_read"])
+
+    def test_message_list_sender_nickname(self) -> None:
+        """메시지 발신자의 닉네임을 올바르게 반환합니다."""
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        messages = response.data["data"]["messages"]
+        # 첫 번째 메시지 (가장 최근 메시지)의 발신자 닉네임 확인
+        self.assertEqual(messages[0]["sender_nickname"], self.user1.nickname)

--- a/apps/chat/tests/test_chat_api.py
+++ b/apps/chat/tests/test_chat_api.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock, patch
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
@@ -114,3 +116,84 @@ class ChatMessageListAPIViewTest(APITestCase):
         messages = response.data["data"]["messages"]
         # 첫 번째 메시지 (가장 최근 메시지)의 발신자 닉네임 확인
         self.assertEqual(messages[0]["sender_nickname"], self.user1.nickname)
+
+    def test_message_list_pagination_logic(self) -> None:
+        """페이지네이션 로직이 올바르게 동작하는지 테스트합니다."""
+        self.client.force_authenticate(user=self.user1)
+        # page=1일 때 300개 메시지 반환
+        response = self.client.get(self.url + "?page=1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]["messages"]), 300)
+        self.assertEqual(response.data["data"]["pagination"]["page"], 1)
+
+        # page=2일 때 100개 메시지 반환 (남은 50개)
+        response = self.client.get(self.url + "?page=2")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["data"]["messages"]), 50)
+        self.assertEqual(response.data["data"]["pagination"]["page"], 2)
+
+    def test_message_list_pagination_none_fallback(self) -> None:
+        """페이지네이션 클래스가 None일 때 ListAPIView의 기본 동작을 테스트합니다."""
+        self.client.force_authenticate(user=self.user1)
+        with patch("apps.chat.views.ChatMessageListView.pagination_class", None):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIsInstance(response.data, list)
+            self.assertEqual(len(response.data), 350)
+
+
+class ChatRoomListAPIViewTest(APITestCase):
+    def setUp(self) -> None:
+        self.user1 = User.objects.create_user(
+            email="user1@example.com",
+            password="password123",
+            nickname="user1",
+            phone_number="01011112222",
+            name="User One",
+            gender="M",
+            birthday="2000-01-01",
+        )
+        self.study_group1 = StudyGroup.objects.create(
+            name="Test Study Group 1",
+            max_headcount=10,
+            start_at="2025-01-01T00:00:00Z",
+            end_at="2025-12-31T23:59:59Z",
+        )
+        GroupMember.objects.create(user=self.user1, study_group=self.study_group1, is_leader=True)
+        self.url = reverse("chat:room-list")
+
+    @patch("apps.chat.views.ChatRoomService.get_chat_rooms_for_user")
+    def test_get_chat_room_list_authenticated(self, mock_get_chat_rooms: Mock) -> None:
+        """인증된 사용자는 채팅방 목록을 조회할 수 있습니다."""
+        mock_get_chat_rooms.return_value = [
+            {
+                "id": self.study_group1.id,
+                "name": self.study_group1.name,
+                "last_message_content": "last message",
+                "last_message_sender_nickname": "sender",
+                "last_message_created_at": "2025-11-01T00:00:00Z",
+                "unread_count": 1,
+            }
+        ]
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], self.study_group1.name)
+        mock_get_chat_rooms.assert_called_once_with(self.user1)
+
+    def test_get_chat_room_list_empty(self) -> None:
+        """참여 중인 채팅방이 없는 경우 빈 목록을 반환합니다."""
+        user_no_group = User.objects.create_user(
+            email="nogroup@example.com",
+            password="password123",
+            nickname="nogroup",
+            phone_number="01077778888",
+            name="No Group User",
+            gender="F",
+            birthday="2000-01-04",
+        )
+        self.client.force_authenticate(user=user_no_group)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)

--- a/apps/chat/tests/test_chat_api.py
+++ b/apps/chat/tests/test_chat_api.py
@@ -4,8 +4,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from apps.chat.models import ChatMessage, LastReadMessage
-from apps.studies.models import StudyGroup
-from apps.studies.models.groups import GroupMember
+from apps.studies.models.groups import GroupMember, StudyGroup
 
 User = get_user_model()
 
@@ -36,12 +35,8 @@ class ChatMessageListAPIViewTest(APITestCase):
             start_at="2025-01-01T00:00:00Z",
             end_at="2025-12-31T23:59:59Z",
         )
-        self.group_member1 = GroupMember.objects.create(
-            user=self.user1, study_group=self.study_group, is_leader=True
-        )
-        self.group_member2 = GroupMember.objects.create(
-            user=self.user2, study_group=self.study_group
-        )
+        self.group_member1 = GroupMember.objects.create(user=self.user1, study_group=self.study_group, is_leader=True)
+        self.group_member2 = GroupMember.objects.create(user=self.user2, study_group=self.study_group)
 
         # Create 350 messages for pagination testing
         for i in range(1, 351):
@@ -51,9 +46,7 @@ class ChatMessageListAPIViewTest(APITestCase):
                 content=f"Message {i}",
             )
 
-        self.url = reverse(
-            "chat:message-list", kwargs={"study_group_id": self.study_group.id}
-        )
+        self.url = reverse("chat:message-list", kwargs={"study_group_id": self.study_group.id})
 
     def test_message_list_unauthenticated(self) -> None:
         """인증되지 않은 사용자는 메시지 목록을 조회할 수 없습니다."""
@@ -99,9 +92,7 @@ class ChatMessageListAPIViewTest(APITestCase):
         """메시지 읽음 상태를 올바르게 반환합니다."""
         # user1이 메시지 300까지 읽었다고 가정
         last_read_message = ChatMessage.objects.get(content="Message 300")
-        LastReadMessage.objects.create(
-            user=self.user1, study_group=self.study_group, message=last_read_message
-        )
+        LastReadMessage.objects.create(user=self.user1, study_group=self.study_group, message=last_read_message)
 
         self.client.force_authenticate(user=self.user1)
         response = self.client.get(self.url)

--- a/apps/chat/tests/test_chat_consumers.py
+++ b/apps/chat/tests/test_chat_consumers.py
@@ -1,7 +1,7 @@
 # apps/chat/tests/test_chat_consumers.py
 import asyncio
 
-from channels.testing import (  # type: ignore[import-untyped]
+from channels.testing import (
     AsgiTestCase,
     WebsocketCommunicator,
 )

--- a/apps/chat/tests/test_chat_services.py
+++ b/apps/chat/tests/test_chat_services.py
@@ -1,0 +1,77 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from apps.chat.models import ChatMessage, LastReadMessage
+from apps.chat.services.chat_room_service import ChatRoomService
+from apps.studies.models.groups import GroupMember, StudyGroup
+
+User = get_user_model()
+
+
+class ChatRoomServiceTest(TestCase):
+    def setUp(self) -> None:
+        self.user1 = User.objects.create_user(
+            email="user1@example.com",
+            password="password123",
+            nickname="user1",
+            phone_number="01011112222",
+            name="User One",
+            gender="M",
+            birthday="2000-01-01",
+        )
+        self.user2 = User.objects.create_user(
+            email="user2@example.com",
+            password="password123",
+            nickname="user2",
+            phone_number="01033334444",
+            name="User Two",
+            gender="F",
+            birthday="2000-01-02",
+        )
+        self.study_group1 = StudyGroup.objects.create(
+            name="Test Study Group 1",
+            max_headcount=10,
+            start_at="2025-01-01T00:00:00Z",
+            end_at="2025-12-31T23:59:59Z",
+        )
+        GroupMember.objects.create(user=self.user1, study_group=self.study_group1, is_leader=True)
+        self.msg1_sg1 = ChatMessage.objects.create(
+            sender=self.user1, study_group=self.study_group1, content="Hello SG1"
+        )
+
+    def test_get_chat_rooms_for_user_no_messages(self) -> None:
+        """메시지가 없는 채팅방의 경우 last_message 관련 필드가 None이어야 합니다."""
+        study_group2 = StudyGroup.objects.create(
+            name="Test Study Group 2",
+            max_headcount=10,
+            start_at="2025-01-01T00:00:00Z",
+            end_at="2025-12-31T23:59:59Z",
+        )
+        GroupMember.objects.create(user=self.user1, study_group=study_group2, is_leader=True)
+
+        chat_rooms = ChatRoomService.get_chat_rooms_for_user(self.user1)
+        chat_rooms_list = list(chat_rooms)
+
+        sg2_data = next((room for room in chat_rooms_list if room["id"] == study_group2.id), None)
+        self.assertIsNotNone(sg2_data)
+        assert sg2_data is not None
+        self.assertIsNone(sg2_data["last_message_content"])
+        self.assertIsNone(sg2_data["last_message_sender_nickname"])
+
+    def test_get_chat_rooms_for_user_all_messages_read(self) -> None:
+        """모든 메시지를 읽었을 때 unread_count가 0이어야 합니다."""
+        LastReadMessage.objects.create(user=self.user1, study_group=self.study_group1, message=self.msg1_sg1)
+
+        chat_rooms = ChatRoomService.get_chat_rooms_for_user(self.user1)
+        chat_rooms_list = list(chat_rooms)
+
+        sg1_data = next((room for room in chat_rooms_list if room["id"] == self.study_group1.id), None)
+        self.assertIsNotNone(sg1_data)
+        assert sg1_data is not None
+        self.assertEqual(sg1_data["unread_count"], 0)
+
+    def test_get_chat_rooms_for_user_not_member(self) -> None:
+        """사용자가 어떤 스터디 그룹의 멤버도 아닌 경우 빈 목록을 반환합니다."""
+        chat_rooms = ChatRoomService.get_chat_rooms_for_user(self.user2)
+        chat_rooms_list = list(chat_rooms)
+        self.assertEqual(len(chat_rooms_list), 0)

--- a/apps/chat/tests/test_pagination.py
+++ b/apps/chat/tests/test_pagination.py
@@ -1,0 +1,50 @@
+from django.test import RequestFactory, TestCase
+from rest_framework.request import Request
+
+from apps.chat.models import ChatMessage
+from apps.chat.pagination import ChatMessagePagination
+from apps.studies.models.groups import GroupMember, StudyGroup
+from apps.users.models import User
+
+
+class ChatMessagePaginationTest(TestCase):
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.pagination = ChatMessagePagination()
+        self.user = User.objects.create_user(
+            email="user1@example.com",
+            password="password123",
+            nickname="user1",
+            phone_number="01011112222",
+            name="User One",
+            gender="M",
+            birthday="2000-01-01",
+        )
+        self.study_group = StudyGroup.objects.create(
+            name="Test Study Group",
+            max_headcount=10,
+            start_at="2025-01-01T00:00:00Z",
+            end_at="2025-12-31T23:59:59Z",
+        )
+        GroupMember.objects.create(user=self.user, study_group=self.study_group, is_leader=True)
+        for i in range(350):
+            ChatMessage.objects.create(
+                sender=self.user,
+                study_group=self.study_group,
+                content=f"Message {i}",
+            )
+        self.queryset = ChatMessage.objects.all().order_by("-created_at")
+
+    def test_second_page_returns_100_messages(self) -> None:
+        """두 번째 페이지는 100개 메시지 반환"""
+        request = self.factory.get("/messages/", {"page": "2"})
+
+        # DRF의 Request 객체로 변환
+        drf_request = Request(request)
+
+        result = self.pagination.paginate_queryset(self.queryset, drf_request)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(len(result), 50)  # 350개 중 첫 페이지 300개 이후 남은 50개
+        self.assertEqual(self.pagination.page_size, 100)

--- a/apps/chat/tests/test_serializers.py
+++ b/apps/chat/tests/test_serializers.py
@@ -1,0 +1,61 @@
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, TestCase
+from rest_framework.request import Request
+
+from apps.chat.models import ChatMessage, LastReadMessage
+from apps.chat.serializers import ChatMessageSerializer
+from apps.studies.models.groups import GroupMember, StudyGroup
+from apps.users.models import User
+
+
+class ChatMessageSerializerTest(TestCase):
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            email="user1@example.com",
+            password="password123",
+            nickname="user1",
+            phone_number="01011112222",
+            name="User One",
+            gender="M",
+            birthday="2000-01-01",
+        )
+        self.study_group = StudyGroup.objects.create(
+            name="Test Study Group",
+            max_headcount=10,
+            start_at="2025-01-01T00:00:00Z",
+            end_at="2025-12-31T23:59:59Z",
+        )
+        GroupMember.objects.create(user=self.user, study_group=self.study_group, is_leader=True)
+        self.message = ChatMessage.objects.create(
+            sender=self.user,
+            study_group=self.study_group,
+            content="Test Message",
+        )
+
+    def test_is_read_without_request_context(self) -> None:
+        """request가 context에 없으면 is_read는 False여야 합니다."""
+        serializer = ChatMessageSerializer(self.message, context={})
+        self.assertFalse(serializer.data["is_read"])
+
+    def test_is_read_with_unauthenticated_user(self) -> None:
+        """비인증 사용자의 경우 is_read는 False여야 합니다."""
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        serializer = ChatMessageSerializer(self.message, context={"request": Request(request)})
+        self.assertFalse(serializer.data["is_read"])
+
+    def test_is_read_without_last_read_message(self) -> None:
+        """LastReadMessage가 없으면 is_read는 False여야 합니다."""
+        request = self.factory.get("/")
+        request.user = self.user
+        serializer = ChatMessageSerializer(self.message, context={"request": Request(request)})
+        self.assertFalse(serializer.data["is_read"])
+
+    def test_is_read_when_message_is_read(self) -> None:
+        """메시지를 읽었을 때 is_read는 True여야 합니다."""
+        LastReadMessage.objects.create(user=self.user, study_group=self.study_group, message=self.message)
+        request = self.factory.get("/")
+        request.user = self.user
+        serializer = ChatMessageSerializer(self.message, context={"request": Request(request)})
+        self.assertTrue(serializer.data["is_read"])

--- a/apps/chat/urls.py
+++ b/apps/chat/urls.py
@@ -1,5 +1,4 @@
-# apps/chat/urls.py
-from django.urls import URLPattern, URLResolver, path
+from django.urls import path
 
 from apps.chat.views import ChatMessageListView, ChatRoomListView
 

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -18,12 +18,12 @@ from apps.studies.models.groups import GroupMember
 from apps.users.models import User
 
 
-class ChatMessageListView(ListAPIView[ChatMessage]):
+class ChatMessageListView(ListAPIView):
     serializer_class = ChatMessageSerializer
     permission_classes = [IsAuthenticated]
     pagination_class = ChatMessagePagination
 
-    def get_queryset(self) -> QuerySet[ChatMessage]:
+    def get_queryset(self):
         study_group_id = self.kwargs["study_group_id"]
         return ChatMessage.objects.filter(study_group_id=study_group_id).order_by("-created_at")
 
@@ -99,10 +99,7 @@ class ChatMessageListView(ListAPIView[ChatMessage]):
         user = request.user
 
         # 사용자가 스터디 그룹의 멤버인지 확인
-        if (
-            not user.is_authenticated
-            or not GroupMember.objects.filter(study_group_id=study_group_id, user=user).exists()
-        ):
+        if not user.is_authenticated or not GroupMember.objects.filter(study_group_id=study_group_id, user=user).exists():
             return Response(
                 {
                     "status": "error",

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -18,12 +18,12 @@ from apps.studies.models.groups import GroupMember
 from apps.users.models import User
 
 
-class ChatMessageListView(ListAPIView):
+class ChatMessageListView(ListAPIView[ChatMessage]):
     serializer_class = ChatMessageSerializer
     permission_classes = [IsAuthenticated]
     pagination_class = ChatMessagePagination
 
-    def get_queryset(self):
+    def get_queryset(self) -> QuerySet[ChatMessage]:
         study_group_id = self.kwargs["study_group_id"]
         return ChatMessage.objects.filter(study_group_id=study_group_id).order_by("-created_at")
 
@@ -99,7 +99,10 @@ class ChatMessageListView(ListAPIView):
         user = request.user
 
         # 사용자가 스터디 그룹의 멤버인지 확인
-        if not user.is_authenticated or not GroupMember.objects.filter(study_group_id=study_group_id, user=user).exists():
+        if (
+            not user.is_authenticated
+            or not GroupMember.objects.filter(study_group_id=study_group_id, user=user).exists()
+        ):
             return Response(
                 {
                     "status": "error",

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,6 +16,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/studies/", include("apps.studies.urls")),
     path("api/v1/recruitments/", include("apps.recruitments.urls")),
     path("api/v1/notifications/", include("apps.notifications.urls")),
+    path("api/v1/chat/", include("apps.chat.urls")),
 ]
 
 if settings.DEBUG:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ python_version = 3.12
 strict = true
 exclude = ["migrations", "manage.py"]
 
+[[tool.mypy.overrides]]
+module = "channels.*"
+ignore_missing_imports = true
+
 
 [tool.django-stubs]
 django_settings_module = "config.settings.local"


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #125 
- 작업 요약: 메시지 내역 조회 API 구현 + is_read 처리 로직 추가 / mypy channels 예외 처리 설정

## 📄 상세 내용
- [x] 메시지 내역 조회 API :

•	기능 :
•	특정 스터디 그룹의 채팅 메시지 내역을 조회
•	페이지네이션 정책
•	1페이지(초기 로드): 기본 반환 개수 300개
•	이후(무한 스크롤): page_size 쿼리로 페이지당 100개 단위 추가 조회 가능(클라이언트가 page_size로 제어)
•	응답 항목: 메시지 id, content, created_at 등 기본 필드와 sender_id, sender_nickname, 그리고 현재 로그인한 사용자 기준의 is_read(읽음 여부)
•	보안: 인증된 사용자만 접근 가능, 해당 스터디 그룹의 멤버가 아니면 403 Forbidden
•	테스트: 인증/권한 검증, 페이지네이션(초기 300개, 이후 페이지), is_read 계산, sender_nickname 반환 등을 포함한 포괄적 테스트 추가 및 통과

- [x] 변경 파일 및 핵심 변경사항:

•	apps/chat/view.py :
•	ChatMessageListView (ListAPIView) 구현
•	extend_schema로 Summary/Description/Parameters/Responses 상세화 (page_size 예시 포함 — 300(초기), 100(무한스크롤)
•	권한(인증 + 스터디 그룹 멤버십) 검증 로직 포함

•	apps/chat/pagination.py :
•	ChatMessagePagination (DRF PageNumberPagination 상속)
•	기본 page_size = 300
•	page_size_query_param = "page_size"
•	DRF 표준 방식으로 paginate_queryset 오버라이드하여 mypy 타입 오류 방지

•	apps/chat/serializers.py :
•	ChatMessageSerializer
•	sender_nickname 및 is_read를 SerializerMethodField로 구현
•	get_is_read는 LastReadMessage 모델을 조회해 로그인 사용자의 읽음 상태를 정확히 반환
	
•	apps/chat/tests/test_chat_api.py :
•	ChatMessageListAPIViewTest 추가
•	범위: 비인증/비멤버 접근 차단, 페이지네이션(초기 300개, 다음 페이지 사이즈), is_read 정확성, sender_nickname 반환 등
	
•	코드 품질
•	mypy, black, isort 통과 보고.
•	테스트 스위트 전체 통과.

- [x] mypy 관련 문제 진단 및 해결 (정확한 원인·해결 기록)

문제 원인
•	channels 패키지에 공식 타입 스텁(stubs)이 포함되어 있지 않음 → mypy가 import-untyped 오류를 발생시킴
•	임시로 # type: ignore[import-untyped]를 import 라인에 추가했으나, black/isort가 임포트 포맷을 변경하면서 주석 위치가 바뀌어 mypy가 unused-ignore 오류를 추가로 보고함
•	포맷터(black/isort)와 정적분석기(mypy)의 주석 해석 방식 충돌이 발생

선택한 해결책(권장·적용된 방식)
•	코드 주석으로 개별적으로 무시하는 방식 대신, pyproject.toml에서 mypy 설정으로 예외 처리(전역 설정) 적용
•	이 설정을 [tool.mypy] 블록 아래에 추가하여 channels 관련 모든 import-untyped 오류를 무시
•	구체 설정(파일에 추가된 내용):

[[tool.mypy.overrides]]
module = "channels.*"
ignore_missing_imports = true

•	결과:
•	코드에 흩어진 # type: ignore[import-untyped] 주석을 제거 (정리함)
•	black/isort의 포맷 변경과 무관하게 mypy가 안정적으로 동작

추가 정리
•	consumers.py, test_chat_consumers.py 등에서 더 이상 필요 없는 # type: ignore 주석을 제거하여 코드 정리 완료
•	mypy 재실행 결과 channels 관련 import-untyped 오류가 더 이상 발생하지 않음

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
