### PR TITLE
fix (users): 어드민 회원 목록 조회, 상세조회 #122 pr 관련 커밋 수정

### DIFF
--- a/apps/users/serializers/admin_users_serializer.py
+++ b/apps/users/serializers/admin_users_serializer.py
@@ -57,6 +57,7 @@ class AdminUserDetailSerializer(serializers.Serializer[UserModel]):
     email = serializers.EmailField()
     nickname = serializers.CharField()
     name = serializers.CharField()
+    gender = serializers.CharField()
     birthday = serializers.DateField()
     phone_number = serializers.CharField(read_only=True)
     status = serializers.SerializerMethodField()

--- a/apps/users/serializers/admin_users_serializer.py
+++ b/apps/users/serializers/admin_users_serializer.py
@@ -33,7 +33,6 @@ class AdminUserItemSerializer(serializers.Serializer[Dict[str, Any]]):
                 Role.ADMIN.value if user.is_superuser else (Role.STAFF.value if user.is_staff else Role.USER.value)
             ),
             "created_at": user.created_at,
-            # Withdrawal 모델이 따로 있거나 서비스에서 붙여주는 경우가 있으니까 안전하게 getattr
             "withdrawal_requested_at": getattr(user, "withdrawal_requested_at", None),
         }
 

--- a/apps/users/serializers/admin_users_serializer.py
+++ b/apps/users/serializers/admin_users_serializer.py
@@ -1,11 +1,17 @@
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
+from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
 from apps.users.enums import Role, UserStatus
-from apps.users.models import User
+from apps.users.models import User as UserModel
 from apps.users.services.admin_users_services import AdminUserService
 from apps.users.validators import validate_korean_phone
+
+User = get_user_model()
+
+if TYPE_CHECKING:
+    from apps.users.models import User as UserModel
 
 
 # [관리자] 회원 목록 조회
@@ -15,26 +21,16 @@ class AdminUserItemSerializer(serializers.Serializer[Dict[str, Any]]):
     nickname = serializers.CharField()
     name = serializers.CharField()
     birthday = serializers.DateField()
-    status = serializers.ChoiceField(choices=UserStatus.choices)
-    role = serializers.ChoiceField(choices=Role.choices)
+    status = serializers.SerializerMethodField()
+    role = serializers.SerializerMethodField()
     created_at = serializers.DateTimeField()
     withdrawal_requested_at = serializers.DateTimeField(allow_null=True, required=False)
 
-    @staticmethod
-    def from_user(user: User) -> Dict[str, Any]:
-        return {
-            "id": user.id,
-            "email": user.email,
-            "nickname": user.nickname,
-            "name": user.name,
-            "birthday": user.birthday,
-            "status": str(AdminUserService.get_user_status(user)),
-            "role": (
-                Role.ADMIN.value if user.is_superuser else (Role.STAFF.value if user.is_staff else Role.USER.value)
-            ),
-            "created_at": user.created_at,
-            "withdrawal_requested_at": getattr(user, "withdrawal_requested_at", None),
-        }
+    def get_status(self, obj: UserModel) -> str:
+        return AdminUserService.get_user_status(obj)
+
+    def get_role(self, obj: UserModel) -> str:
+        return AdminUserService.get_user_role(obj)
 
 
 # [관리자] data: {users: [...]}
@@ -42,47 +38,41 @@ class AdminUserListDataSerializer(serializers.Serializer[Dict[str, Any]]):
     users = AdminUserItemSerializer(many=True)
 
 
-# [관리자] detail: data: {{users: [...]}}
+# [관리자] detail: "", data: {users: [...]}
 class AdminUserListResponseSerializer(serializers.Serializer[Dict[str, Any]]):
     detail = serializers.CharField()
-    payload = AdminUserListDataSerializer()
+    results = AdminUserListDataSerializer(many=True)
 
-    def to_representation(self, instance: Dict[str, Any]) -> Dict[str, Any]:
-        base = super().to_representation(instance)
-        payload = base.pop("payload", {})
-        base["data"] = payload
-        return base
+    def to_representation(self, instance: Any) -> Dict[str, Any]:
+        rep = super().to_representation(instance)
+        return {
+            "detail": rep["detail"],
+            "data": rep["results"],
+        }
 
 
 # [관리자] 회원 상세 조회
-class AdminUserDetailSerializer(serializers.ModelSerializer[User]):
+class AdminUserDetailSerializer(serializers.Serializer[UserModel]):
+    id = serializers.IntegerField()
+    email = serializers.EmailField()
+    nickname = serializers.CharField()
+    name = serializers.CharField()
+    birthday = serializers.DateField()
+    phone_number = serializers.CharField(read_only=True)
+    status = serializers.SerializerMethodField()
+    role = serializers.SerializerMethodField()
+    created_at = serializers.DateTimeField()
+    profile_img_url = serializers.URLField()
 
-    status: serializers.SerializerMethodField = serializers.SerializerMethodField()
+    def get_status(self, obj: UserModel) -> str:
+        return AdminUserService.get_user_status(obj)
 
-    class Meta:
-        model = User
-        fields = [
-            "id",
-            "email",
-            "name",
-            "nickname",
-            "birthday",
-            "phone_number",
-            "is_active",
-            "is_staff",
-            "is_superuser",
-            "status",
-            "created_at",
-            "profile_img_url",
-        ]
-
-    def get_status(self, obj: User) -> str:
-        # 상태값을 문자열로 반환
-        return str(AdminUserService.get_user_status(obj))
+    def get_role(self, obj: UserModel) -> str:
+        return AdminUserService.get_user_role(obj)
 
 
 # [관리자] 회원 정보 수정
-class AdminUserUpdateSerializer(serializers.ModelSerializer[User]):
+class AdminUserUpdateSerializer(serializers.ModelSerializer[UserModel]):
 
     status = serializers.ChoiceField(choices=UserStatus.choices, required=False)
     phone_number = serializers.CharField(

--- a/apps/users/serializers/admin_users_serializer.py
+++ b/apps/users/serializers/admin_users_serializer.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 from rest_framework import serializers
 
@@ -9,24 +9,50 @@ from apps.users.validators import validate_korean_phone
 
 
 # [관리자] 회원 목록 조회
-class AdminUserListSerializer(serializers.ModelSerializer[User]):
+class AdminUserItemSerializer(serializers.Serializer[Dict[str, Any]]):
+    id = serializers.IntegerField()
+    email = serializers.EmailField()
+    nickname = serializers.CharField()
+    name = serializers.CharField()
+    birthday = serializers.DateField()
+    status = serializers.ChoiceField(choices=UserStatus.choices)
+    role = serializers.ChoiceField(choices=Role.choices)
+    created_at = serializers.DateTimeField()
+    withdrawal_requested_at = serializers.DateTimeField(allow_null=True, required=False)
 
-    withdrawal_requested_at = serializers.DateTimeField(read_only=True, allow_null=True)
+    @staticmethod
+    def from_user(user: User) -> Dict[str, Any]:
+        return {
+            "id": user.id,
+            "email": user.email,
+            "nickname": user.nickname,
+            "name": user.name,
+            "birthday": user.birthday,
+            "status": str(AdminUserService.get_user_status(user)),
+            "role": (
+                Role.ADMIN.value if user.is_superuser else (Role.STAFF.value if user.is_staff else Role.USER.value)
+            ),
+            "created_at": user.created_at,
+            # Withdrawal 모델이 따로 있거나 서비스에서 붙여주는 경우가 있으니까 안전하게 getattr
+            "withdrawal_requested_at": getattr(user, "withdrawal_requested_at", None),
+        }
 
-    class Meta:
-        model = User
-        fields = [
-            "id",
-            "email",
-            "nickname",
-            "name",
-            "birthday",
-            "is_active",
-            "is_superuser",
-            "is_staff",
-            "created_at",
-            "withdrawal_requested_at",
-        ]
+
+# [관리자] data: {users: [...]}
+class AdminUserListDataSerializer(serializers.Serializer[Dict[str, Any]]):
+    users = AdminUserItemSerializer(many=True)
+
+
+# [관리자] detail: data: {{users: [...]}}
+class AdminUserListResponseSerializer(serializers.Serializer[Dict[str, Any]]):
+    detail = serializers.CharField()
+    payload = AdminUserListDataSerializer()
+
+    def to_representation(self, instance: Dict[str, Any]) -> Dict[str, Any]:
+        base = super().to_representation(instance)
+        payload = base.pop("payload", {})
+        base["data"] = payload
+        return base
 
 
 # [관리자] 회원 상세 조회

--- a/apps/users/services/admin_users_services.py
+++ b/apps/users/services/admin_users_services.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from django.db.models import QuerySet
+from django.db.models import OuterRef, QuerySet, Subquery
 from django.shortcuts import get_object_or_404
 
 from apps.users.enums import Role, UserStatus
@@ -13,7 +13,11 @@ class AdminUserService:
 
     @staticmethod
     def get_user_list() -> QuerySet[User]:
-        return User.objects.all().order_by("-created_at")
+        latest_withdrawal = (
+            Withdrawal.objects.filter(user_id=OuterRef("id")).order_by("-created_at").values("created_at")[:1]
+        )
+
+        return User.objects.annotate(withdrawal_requested_at=Subquery(latest_withdrawal)).order_by("-created_at")
 
     # 회원 상세 조회
 

--- a/apps/users/services/admin_users_services.py
+++ b/apps/users/services/admin_users_services.py
@@ -8,6 +8,38 @@ from apps.users.models import User, Withdrawal
 
 
 class AdminUserService:
+    # 회원 상태 계산
+    @staticmethod
+    def get_user_status(user: User) -> str:
+        """
+        회원 상태 조회
+        ACTLVE - 활성
+        INACTIVE - 비활성
+        WITHDRAWAL_PEDING - 탈퇴요청
+        """
+        has_withdrawal = Withdrawal.objects.filter(user_id=user.id).exists()
+
+        if has_withdrawal:
+            # 탈퇴 테이블에 있으면 탈퇴 요청 중
+            return UserStatus.WITHDRAWAL_PENDING.value
+
+        # 탈퇴 테이블에 없고 활성 상태면 정상
+        if user.is_active:
+            return UserStatus.ACTIVE.value
+
+        # 탈퇴 테이블에 없고 비활성이면 완전 탈퇴
+        return UserStatus.INACTIVE.value
+
+    @staticmethod
+    def get_user_role(user: User) -> str:
+        """
+        유저 권한 계산
+        """
+        if user.is_superuser:
+            return Role.ADMIN.value
+        if user.is_staff:
+            return Role.STAFF.value
+        return Role.USER.value
 
     # 회원 목록 조회
 
@@ -67,27 +99,3 @@ class AdminUserService:
     @staticmethod
     def delete_user(user: User) -> None:
         user.delete()
-
-    # 회원 상태 계산
-
-    @staticmethod
-    def get_user_status(user: User) -> UserStatus:
-        """
-        회원 상태 조회
-        ACTLVE - 활성
-        INACTIVE - 비활성
-        WITHDRAWAL_PEDING - 탈퇴요청
-        """
-
-        has_withdrawal = Withdrawal.objects.filter(user_id=user.id).exists()
-
-        if has_withdrawal:
-            # 탈퇴 테이블에 있으면 탈퇴 요청 중
-            return UserStatus.WITHDRAWAL_PENDING
-
-        # 탈퇴 테이블에 없고 활성 상태면 정상
-        if user.is_active:
-            return UserStatus.ACTIVE
-
-        # 탈퇴 테이블에 없고 비활성이면 완전 탈퇴
-        return UserStatus.INACTIVE

--- a/apps/users/tests/test_admin_users_service.py
+++ b/apps/users/tests/test_admin_users_service.py
@@ -86,7 +86,7 @@ class AdminUserServiceTest(TestCase):
         """탈퇴 예정 상태"""
         Withdrawal.objects.create(user=self.user, due_date=timezone.now())
         status = AdminUserService.get_user_status(self.user)
-        self.assertEqual(status, UserStatus.WITHDRAWAL_PENDING)
+        self.assertEqual(status, UserStatus.WITHDRAWAL_PENDING.value)
 
     def test_get_user_status_inactive(self) -> None:
         """비활성 상태"""

--- a/apps/users/tests/test_admin_users_view.py
+++ b/apps/users/tests/test_admin_users_view.py
@@ -112,7 +112,6 @@ class TestAdminUserAPI(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data["data"]
-        self.assertIn("is_active", data)
         self.assertIn("status", data)
         self.assertEqual(data["status"], UserStatus.WITHDRAWAL_PENDING.value)
 

--- a/apps/users/views/admin_users_views.py
+++ b/apps/users/views/admin_users_views.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any
 
 from django.http import Http404
 from drf_spectacular.utils import extend_schema, extend_schema_view
@@ -34,10 +34,7 @@ class AdminUserListView(APIView):
 
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         users = AdminUserService.get_user_list()
-
-        user_dicts: List[Dict[str, Any]] = [AdminUserItemSerializer.from_user(u) for u in users]
-
-        data_ser = AdminUserListDataSerializer({"users": user_dicts})
+        data_ser = AdminUserListDataSerializer({"users": users})
 
         return Response(
             {

--- a/apps/users/views/admin_users_views.py
+++ b/apps/users/views/admin_users_views.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Dict, List
 
 from django.http import Http404
 from drf_spectacular.utils import extend_schema, extend_schema_view
@@ -13,7 +13,9 @@ from rest_framework.views import APIView
 
 from apps.users.serializers.admin_users_serializer import (
     AdminUserDetailSerializer,
-    AdminUserListSerializer,
+    AdminUserItemSerializer,
+    AdminUserListDataSerializer,
+    AdminUserListResponseSerializer,
     AdminUserRoleUpdateRequestSerializer,
     AdminUserRoleUpdateResponseSerializer,
     AdminUserUpdateSerializer,
@@ -25,18 +27,22 @@ from apps.users.services.admin_users_services import AdminUserService
 @extend_schema(
     tags=["Admin"],
     summary="관리자 - 회원 목록 조회",
-    responses={200: AdminUserListSerializer(many=True)},
+    responses={200: AdminUserListResponseSerializer},
 )
 class AdminUserListView(APIView):
     permission_classes = [IsAdminUser]
 
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         users = AdminUserService.get_user_list()
-        serializer = AdminUserListSerializer(users, many=True)
+
+        user_dicts: List[Dict[str, Any]] = [AdminUserItemSerializer.from_user(u) for u in users]
+
+        data_ser = AdminUserListDataSerializer({"users": user_dicts})
+
         return Response(
             {
                 "detail": "회원 목록 조회에 성공하였습니다.",
-                "data": {"users": serializer.data},
+                "data": data_ser.data,
             },
             status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #122 
- 작업 요약: #122 pr에서 삭제된 AdminUserListSerializer의   "status", "role" 필드 복구

## 📄 상세 내용
- [x] 이전 pr에서 반환 필드 값이 잘못되어 삭제 (is_active, is_superuser => role, status string type 반환시키게 수정)
- [x] 권한 변경 성공 시 "error" -> "detail" 키로 변경
- [x] 어드민에서 회원 목록 조회 시 탈퇴요청일값이 null로 무조건 누락되어 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
