### PR TITLE
♻️ refactor(users): 중복 닉네임 API 409 예외처리 및 Auth & UserProfile API 응답 구조 개선

### DIFF
--- a/apps/users/managers/managers.py
+++ b/apps/users/managers/managers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Optional
+from datetime import datetime, time
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 from django.contrib.auth.base_user import BaseUserManager
 from django.db import models
@@ -82,22 +82,30 @@ class UserManager(BaseUserManager["User"]):
         """
         return self.get_queryset().exists_nickname(nickname)
 
-    def is_email_blocked_by_recent_withdrawal(self, email: str, days: int = 30) -> bool:
+    def is_email_blocked_by_recent_withdrawal(self, email: str) -> Tuple[bool, Optional[datetime]]:
         """
-        최근 n일 이내 해당 이메일 유저가 탈퇴한 적 있는지 여부
+        최근 탈퇴로 인한 재가입 차단 상태와 차단 만료시각(block_until) 반환
         """
         email = self.normalize_email(email)
-        limit = timezone.now() - timedelta(days=days)
+        now = timezone.now()
 
         user = self.get_queryset().inactive().filter(email=email).first()
 
         if not user:
-            return False
+            return False, None
 
-        return Withdrawal.objects.filter(
-            user_id=user.id,
-            created_at__gte=limit,
-        ).exists()
+        due_date = (
+            Withdrawal.objects.filter(user_id=user.id).order_by("-due_date").values_list("due_date", flat=True).first()
+        )
+
+        if not due_date:
+            return False, None
+
+        block_until = timezone.make_aware(datetime.combine(due_date, time(23, 59, 59)))
+
+        if block_until > now:
+            return True, block_until
+        return False, None
 
     def create_user(self, email: str, password: Optional[str] = None, **extra_fields: object) -> "User":
         """유저 생성: 이메일 정규화 적용 + 비밀번호 설정(None이면 unusable)"""

--- a/apps/users/serializers/user_profile_serializers.py
+++ b/apps/users/serializers/user_profile_serializers.py
@@ -89,7 +89,7 @@ class DupNicknameQuerySerializer(serializers.Serializer[dict[str, Any]]):
     닉네임 중복 확인 쿼리 파라미터
     """
 
-    nickname = serializers.CharField(required=True, trim_whitespace=True)
+    nickname = serializers.CharField(max_length=10, min_length=1, required=True, trim_whitespace=True)
     case_insensitive = serializers.BooleanField(required=False, default=True)
 
 

--- a/apps/users/services/user_signup_service.py
+++ b/apps/users/services/user_signup_service.py
@@ -4,9 +4,11 @@ from dataclasses import dataclass
 
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
+from django.utils.timezone import localtime
 from rest_framework import status
 from rest_framework.exceptions import APIException, ValidationError
 
+from apps.core.exceptions import Conflict
 from apps.users.enums import Role
 from apps.users.models.user import User as UserModel
 from apps.users.serializers.user_signup_serializers import SignupPayload
@@ -168,8 +170,10 @@ class DefaultSignupService:
             conflicts.setdefault("email", []).append("이미 사용 중인 이메일입니다.")
 
         # 2) 최근 14일 이내 탈퇴 이메일 차단
-        if User.objects.is_email_blocked_by_recent_withdrawal(email, days=14):
-            conflicts.setdefault("email", []).append("탈퇴 요청 처리중입니다.")
+        blocked, block_until = User.objects.is_email_blocked_by_recent_withdrawal(email)
+        if blocked and block_until:
+            date_str = localtime(block_until).strftime("%Y년 %m월 %d일")
+            raise Conflict(f"탈퇴 처리 중인 계정입니다. {date_str} 이후 가입이 가능합니다.")
 
         # 3) 닉네임 중복
         if User.objects.exists_nickname(nickname):

--- a/apps/users/tests/test_auth_token.py
+++ b/apps/users/tests/test_auth_token.py
@@ -301,8 +301,16 @@ class AuthViewsTest(TestCase):
         self.client.cookies[settings.AUTH_REFRESH_COOKIE_NAME] = str(refresh_token)
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {str(access_token)}")  # APIClient로 인증된 상태 설정
 
-        with patch("apps.users.views.auth_views.RefreshToken.blacklist", side_effect=TokenError) as mock_blacklist:
-            resp = self.client.post(self.logout_url, data=json.dumps({}), content_type="application/json")
+        with patch.object(
+            RefreshToken,
+            "blacklist",
+            side_effect=TokenError("세션이 유효하지 않습니다. 다시 로그인해주세요."),
+        ):
+            resp = self.client.post(
+                self.logout_url,
+                data=json.dumps({}),
+                content_type="application/json",
+            )
 
         # 이미 로그아웃된 경우 처리
         self.assertEqual(resp.status_code, 200)

--- a/apps/users/tests/test_user_profile_api.py
+++ b/apps/users/tests/test_user_profile_api.py
@@ -141,47 +141,35 @@ class UserDupNicknameViewTests(TestCase):
     def test_default_case_insensitive_duplicates(self) -> None:
         # 기본값: 대소문자 구분 안함 → Winter vs winter => 중복
         resp = self.client.get(self.url, {"nickname": "winter"})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
-        self.assertIn("detail", body)
-        self.assertIn("data", body)
-        self.assertEqual(body["data"]["nickname"], "winter")
-        self.assertFalse(body["data"]["available"])  # 중복
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.json()["error"], "이미 사용중인 닉네임입니다.")
 
     def test_not_duplicate_when_not_exists(self) -> None:
         resp = self.client.get(self.url, {"nickname": "BrandNewNick"})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
-        self.assertTrue(body["data"]["available"])  # 사용 가능
-        self.assertEqual(body["data"]["nickname"], "BrandNewNick")
+        self.assertEqual(resp.status_code, 400)
 
     def test_case_sensitive_false_flag(self) -> None:
         # case_insensitive=false → 대소문자 지켜서 중복 확인
         resp = self.client.get(self.url, {"nickname": "winter", "case_insensitive": "false"})
         self.assertEqual(resp.status_code, 200)
-        body = resp.json()
-        self.assertTrue(body["data"]["available"])
 
         resp2 = self.client.get(self.url, {"nickname": "Winter", "case_insensitive": "false"})
-        self.assertEqual(resp2.status_code, 200)
-        self.assertFalse(resp2.json()["data"]["available"])
+        self.assertEqual(resp2.status_code, 409)
 
     def test_trims_spaces(self) -> None:
         # 앞뒤 공백 제거되어 Winter 비교 → 중복
         resp = self.client.get(self.url, {"nickname": "  Winter  "})
-        self.assertEqual(resp.status_code, 200)
-        self.assertFalse(resp.json()["data"]["available"])
+        self.assertEqual(resp.status_code, 409)
 
     def test_truthy_values_for_case_insensitive(self) -> None:
         # true/1만 true로 처리 ({"1","true"}만 true)
         # "true" → 중복
         resp_true = self.client.get(self.url, {"nickname": "winter", "case_insensitive": "true"})
-        self.assertFalse(resp_true.json()["data"]["available"])
-
+        self.assertEqual(resp_true.json()["error"], "이미 사용중인 닉네임입니다.")
         # "1" → 중복
         resp_one = self.client.get(self.url, {"nickname": "winter", "case_insensitive": "1"})
-        self.assertFalse(resp_one.json()["data"]["available"])
+        self.assertEqual(resp_one.json()["error"], "이미 사용중인 닉네임입니다.")
 
         # "0" → false 처리 → 대소문 구분
         resp_yes = self.client.get(self.url, {"nickname": "winter", "case_insensitive": "0"})
-        self.assertTrue(resp_yes.json()["data"]["available"])
+        self.assertEqual(resp_yes.json()["detail"], "사용 가능한 닉네임입니다.")

--- a/apps/users/views/auth_views.py
+++ b/apps/users/views/auth_views.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, cast
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import validate_email as django_validate_email
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -32,6 +32,7 @@ from apps.users.services.auth_services import (
 )
 from apps.users.utils.cookies import set_refresh_cookie
 from apps.users.utils.jwt import extract_bearer_token, is_jwt_like
+from apps.users.utils.response_helpers import ok
 
 
 # ==============================
@@ -132,14 +133,6 @@ class TokenRefreshView(APIView):
         description=(
             "리프레시 토큰은 **HttpOnly 쿠키**에서 읽어 재발급\n" f"- 쿠키 키: `{settings.AUTH_REFRESH_COOKIE_NAME}`\n"
         ),
-        parameters=[
-            OpenApiParameter(
-                name=settings.AUTH_REFRESH_COOKIE_NAME,
-                location=OpenApiParameter.COOKIE,
-                required=True,
-                description="리프레시 토큰이 저장된 HttpOnly 쿠키",
-            ),
-        ],
         request=None,
         responses={200: TokenRefreshResponseSerializer},
     )
@@ -188,7 +181,7 @@ class LogoutView(ExceptionHandledAPIView):
     @extend_schema(
         tags=["Auth"],
         summary="로그아웃",
-        description=("쿠키의 refresh를 캐시 denylist로 무효화하고 삭제"),
+        description=("쿠키의 refresh를 무효화하고 삭제"),
         request=None,
         responses={200: {"type": "object", "properties": {"detail": {"type": "string"}}}},
     )
@@ -196,21 +189,36 @@ class LogoutView(ExceptionHandledAPIView):
         refresh_raw = request.COOKIES.get(settings.AUTH_REFRESH_COOKIE_NAME)
         access_token = extract_bearer_token(request)
 
-        if not refresh_raw or not access_token:
-            return Response({"detail": "세션이 유효하지 않습니다. 다시 로그인해주세요."}, status=200)
+        def _ok(detail: str, code: int = status.HTTP_200_OK) -> Response:
+            resp = ok(detail, status_code=code)
+            resp.delete_cookie(settings.AUTH_REFRESH_COOKIE_NAME)
+            return resp
 
-        refresh_token = RefreshToken(cast(Any, refresh_raw))
+        def _err(msg: str, code: int) -> Response:
+            resp = Response({"error": msg}, status=code)
+            resp.delete_cookie(settings.AUTH_REFRESH_COOKIE_NAME)
+            return resp
+
+        if not refresh_raw or not access_token:
+            return _ok("세션이 유효하지 않습니다. 다시 로그인해주세요.")
+
+        try:
+            refresh_token = RefreshToken(cast(Any, refresh_raw))
+        except InvalidToken:
+            return _err("유효하지 않은 토큰입니다.", status.HTTP_401_UNAUTHORIZED)
+        except ExpiredTokenError:
+            return _err("토큰이 만료되었습니다.", status.HTTP_401_UNAUTHORIZED)
+        except TokenError:
+            return _ok("세션이 유효하지 않습니다. 다시 로그인해주세요.")
 
         try:
             refresh_token.blacklist()
         except InvalidToken:
-            return Response({"error": "유효하지 않은 토큰입니다."}, status=401)
+            return _err("유효하지 않은 토큰입니다.", status.HTTP_401_UNAUTHORIZED)
         except ExpiredTokenError:
-            return Response({"error": "토큰이 만료되었습니다."}, status=401)
+            return _err("토큰이 만료되었습니다.", status.HTTP_401_UNAUTHORIZED)
         except TokenError:
             # 이미 블랙리스트에 있을 경우 성공 처리
-            return Response({"detail": "세션이 유효하지 않습니다. 다시 로그인해주세요."}, status=200)
+            return _ok("세션이 유효하지 않습니다. 다시 로그인해주세요.")
 
-        resp = Response({"detail": "로그아웃이 완료되었습니다."}, status=200)
-        resp.delete_cookie(settings.AUTH_REFRESH_COOKIE_NAME)
-        return resp
+        return _ok("로그아웃이 완료되었습니다.")

--- a/apps/users/views/email_verification_views.py
+++ b/apps/users/views/email_verification_views.py
@@ -10,8 +10,8 @@ from rest_framework.permissions import AllowAny, BasePermission, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
-from rest_framework.views import APIView
 
+from apps.core.views import ExceptionHandledAPIView
 from apps.users.enums import EmailVerificationPurpose
 from apps.users.serializers.email_verification_serializers import (
     EmailVerificationRequestSerializer,
@@ -61,7 +61,7 @@ def _build_confirm_payload(
 # =============================================================================
 # 공통뷰: 이메일 인증코드 전송
 # =============================================================================
-class _BaseEmailSendCodeView(APIView):
+class _BaseEmailSendCodeView(ExceptionHandledAPIView):
     """
     이메일 인증코드 전송 공통 베이스
     - 하위 클래스에서 authentication_classes / permission_classes / PURPOSE 지정
@@ -97,7 +97,7 @@ class _BaseEmailSendCodeView(APIView):
 # =============================================================================
 # 공통뷰: 이메일 인증코드 확인
 # =============================================================================
-class _BaseEmailConfirmCodeView(APIView):
+class _BaseEmailConfirmCodeView(ExceptionHandledAPIView):
     """
     이메일 인증코드 확인 공통 베이스
     """

--- a/apps/users/views/user_profile_views.py
+++ b/apps/users/views/user_profile_views.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.core.exceptions import Conflict
 from apps.core.views import ExceptionHandledAPIView
 from apps.users.models.user import User
 from apps.users.serializers.user_profile_serializers import (
@@ -67,9 +68,11 @@ class UserDupNicknameView(ExceptionHandledAPIView):
         filters_ = {"nickname__iexact": nickname} if case_insensitive else {"nickname": nickname}
         is_dup = User.objects.filter(**filters_).exists()
 
+        if is_dup:
+            raise Conflict("이미 사용중인 닉네임입니다.")
+
         return ok(
-            "이미 사용중인 닉네임입니다." if is_dup else "사용 가능한 닉네임입니다.",
-            data={"nickname": nickname, "available": not is_dup},
+            "사용 가능한 닉네임입니다.",
             status_code=status.HTTP_200_OK,
         )
 


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약:
- 회원가입 API 재가입 유저 예외처리 메세지 수정 *프론트엔드 요청
-  닉네임 중복 확인 API의 409 예외처리 추가 *프론트엔드 요청
-  이메일 인증/검증 API 공통 예외 처리 기반 클래스로 통합
-  로그아웃 View 중복 로직 정리
- 
## 📄 상세 내용
- [x] 회원가입 API: 재가입 불가 유저의 경우 재가입 가능일 예외 메세지에 포함되게 수정
<img width="600" height="210" alt="image" src="https://github.com/user-attachments/assets/c1a6ea9e-3d7d-4274-85c4-bd95c9baa290" />


- [x] 닉네임 중복 확인 API: 
          1) 기존 닉넴 중복 시 200 코드에 중복 여부 True 로 반환했으나, 프론트엔드 요청으로 409 예외처리로 변경
          2) nickname 필드에 max_length=10, min_length=1 검증 추가.
          
- [x] 이메일 인증/검증 API: ExceptionHandledAPIView 공통 예외 처리 기반 클래스 적용
- [x] 로그아웃 View: 중복되는 Response/delete_cookie 로직을 _ok(), _err() 함수로 정리

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
