### PR TITLE
✨ Feat: 스터디그룹 CRU API 프론트 요구사항 반영하여 코드 추가

### DIFF
--- a/apps/studies/permissions.py
+++ b/apps/studies/permissions.py
@@ -22,9 +22,16 @@ from apps.studies.models.notes import StudyNote
 class IsGroupLeader(BasePermission):
     message = "리더만 접근 가능한 기능입니다."
 
-    def has_permission(self, request: Request, view: APIView) -> bool:
-        group = getattr(view, "mock_group", None)
-        return bool(request.user and group)
+    def has_object_permission(self, request: Request, view: APIView, obj: StudyGroup) -> bool:
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+
+        return GroupMember.objects.filter(
+            study_group=obj,
+            user=user,
+            is_leader=True,
+        ).exists()
 
 
 class IsGroupMemberDOP(DjangoObjectPermissions):

--- a/apps/studies/serializers/groups.py
+++ b/apps/studies/serializers/groups.py
@@ -136,14 +136,11 @@ class StudyGroupListSerializer(StudyGroupBaseSerializer):
 
         return any(member.user.id == req_user_id and member.is_leader for member in members)
 
-    def get_total_pages(self, obj: StudyGroup) -> int:
-        total_groups = StudyGroup.objects.count()
-        page_size = 9
-
-        return math.ceil(total_groups / page_size)
-
     def get_total_groups(self, obj: StudyGroup) -> int:
-        return StudyGroup.objects.count()
+        return self.context.get("total_groups", 0)
+
+    def get_total_pages(self, obj: StudyGroup) -> int:
+        return self.context.get("total_pages", 0)
 
 
 class StudyGroupDetailLectureSerializer(serializers.ModelSerializer[CrawledLecture]):

--- a/apps/studies/serializers/groups.py
+++ b/apps/studies/serializers/groups.py
@@ -1,9 +1,8 @@
+import math
 from datetime import timedelta
-from typing import Any, Dict, cast
-from uuid import UUID
+from typing import Any, Dict
 
 from django.db import transaction
-from django.db.models import QuerySet
 from django.utils import timezone
 from rest_framework import serializers
 
@@ -35,8 +34,8 @@ class StudyGroupCreateSerializer(StudyGroupBaseSerializer):
     )
     profile_img_url = serializers.URLField(required=False, allow_null=True, help_text="프로필 이미지 URL (선택사항)")
     max_headcount = serializers.IntegerField(help_text="최대 인원 수 (2~10명)")
-    start_at = serializers.DateTimeField(help_text="스터디 시작일")
-    end_at = serializers.DateTimeField(help_text="스터디 종료일")
+    start_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S", help_text="스터디 시작일")
+    end_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S", help_text="스터디 종료일")
     lectures = serializers.SlugRelatedField(
         queryset=CrawledLecture.objects.all(),
         many=True,
@@ -116,12 +115,16 @@ class StudyGroupListSerializer(StudyGroupBaseSerializer):
     current_headcount = serializers.IntegerField()
     is_leader = serializers.SerializerMethodField()
     lectures = StudyGroupListLectureSerializer(many=True)
+    total_pages = serializers.SerializerMethodField()
+    total_groups = serializers.SerializerMethodField()
 
     class Meta(StudyGroupBaseSerializer.Meta):
         fields = StudyGroupBaseSerializer.Meta.fields + [
             "current_headcount",
             "is_leader",
             "lectures",
+            "total_pages",
+            "total_groups",
         ]
 
     def get_is_leader(self, obj: StudyGroup) -> bool:
@@ -132,6 +135,15 @@ class StudyGroupListSerializer(StudyGroupBaseSerializer):
         members = obj.group_members.all()
 
         return any(member.user.id == req_user_id and member.is_leader for member in members)
+
+    def get_total_pages(self) -> int:
+        total_groups = StudyGroup.objects.count()
+        page_size = 9
+
+        return math.ceil(total_groups / page_size)
+
+    def get_total_groups(self) -> int:
+        return StudyGroup.objects.count()
 
 
 class StudyGroupDetailLectureSerializer(serializers.ModelSerializer[CrawledLecture]):
@@ -153,21 +165,17 @@ class StudyGroupDetailSerializer(StudyGroupBaseSerializer):
     current_headcount = serializers.SerializerMethodField()
     members = StudyGroupDetailMemberSerializer(source="group_members", many=True)
     lectures = StudyGroupDetailLectureSerializer(many=True)
+    is_me_leader = serializers.SerializerMethodField()
 
     class Meta(StudyGroupBaseSerializer.Meta):
-        fields = StudyGroupBaseSerializer.Meta.fields + ["current_headcount", "members", "lectures"]
+        fields = StudyGroupBaseSerializer.Meta.fields + ["current_headcount", "members", "lectures", "is_me_leader"]
 
     def get_current_headcount(self, obj: StudyGroup) -> int:
         return len(obj.members.all())
 
-    def get_members(self, obj: StudyGroup) -> list[dict[str, int | str | UUID]]:
-        group_members = cast(QuerySet[GroupMember], obj.members.all())
+    def get_is_me_leader(self, obj: StudyGroup) -> bool:
+        request = self.context.get("request")
+        if not request or not hasattr(request, "user"):
+            return False
 
-        return [
-            {
-                "uuid": group_member.user.uuid,
-                "nickname": group_member.user.nickname,
-                "is_leader": group_member.is_leader,
-            }
-            for group_member in group_members
-        ]
+        return obj.members.filter(user=request.user, groupmember__is_leader=True).exists()

--- a/apps/studies/serializers/groups.py
+++ b/apps/studies/serializers/groups.py
@@ -136,13 +136,13 @@ class StudyGroupListSerializer(StudyGroupBaseSerializer):
 
         return any(member.user.id == req_user_id and member.is_leader for member in members)
 
-    def get_total_pages(self) -> int:
+    def get_total_pages(self, obj: StudyGroup) -> int:
         total_groups = StudyGroup.objects.count()
         page_size = 9
 
         return math.ceil(total_groups / page_size)
 
-    def get_total_groups(self) -> int:
+    def get_total_groups(self, obj: StudyGroup) -> int:
         return StudyGroup.objects.count()
 
 
@@ -178,4 +178,4 @@ class StudyGroupDetailSerializer(StudyGroupBaseSerializer):
         if not request or not hasattr(request, "user"):
             return False
 
-        return obj.members.filter(user=request.user, groupmember__is_leader=True).exists()
+        return GroupMember.objects.filter(study_group=obj, user=request.user, is_leader=True).exists()

--- a/apps/studies/serializers/groups.py
+++ b/apps/studies/serializers/groups.py
@@ -1,6 +1,5 @@
-import math
 from datetime import timedelta
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 from django.db import transaction
 from django.utils import timezone
@@ -137,10 +136,10 @@ class StudyGroupListSerializer(StudyGroupBaseSerializer):
         return any(member.user.id == req_user_id and member.is_leader for member in members)
 
     def get_total_groups(self, obj: StudyGroup) -> int:
-        return self.context.get("total_groups", 0)
+        return cast(int, self.context.get("total_groups", 0))
 
     def get_total_pages(self, obj: StudyGroup) -> int:
-        return self.context.get("total_pages", 0)
+        return cast(int, self.context.get("total_pages", 0))
 
 
 class StudyGroupDetailLectureSerializer(serializers.ModelSerializer[CrawledLecture]):

--- a/apps/studies/tests/test_groups.py
+++ b/apps/studies/tests/test_groups.py
@@ -381,7 +381,7 @@ class StudyGroupDetailUpdateViewTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_update_group_not_found(self) -> None:
-        wrong_url = f"/api/v1/studies/groups/{uuid.uuid4()}"
+        wrong_url = reverse("studies:study-group-detail-update", kwargs={"group_uuid": uuid.uuid4()})
         data = {"name": "존재하지 않는 그룹"}
 
         response = self.client.put(wrong_url, data, content_type="application/json")

--- a/apps/studies/views/groups.py
+++ b/apps/studies/views/groups.py
@@ -105,6 +105,8 @@ class StudyGroupDetailUpdateView(APIView):
         obj_uuid = self.kwargs.get("group_uuid")
         obj = get_object_or_404(StudyGroup.objects.prefetch_related("lectures"), uuid=obj_uuid)
 
+        self.check_object_permissions(request, obj)
+
         serializer = StudyGroupCreateSerializer(obj, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/apps/studies/views/groups.py
+++ b/apps/studies/views/groups.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, List, cast
 
 from django.db.models import Count
@@ -50,6 +51,8 @@ class StudyGroupListCreateView(APIView):
     def get(self, request: Request) -> Response:
 
         queryset = StudyGroup.objects.order_by("-created_at")
+        total_groups = queryset.count()
+        total_pages = math.ceil(total_groups / StudyGroupPagination.page_size)
 
         status_param = request.query_params.get("status")
         if status_param == "ENDED":
@@ -61,7 +64,7 @@ class StudyGroupListCreateView(APIView):
 
         paginator = self.pagination_class()
         page = paginator.paginate_queryset(queryset, self.request)
-        serializer = StudyGroupListSerializer(page, many=True, context={"request": request})
+        serializer = StudyGroupListSerializer(page, many=True, context={"request": request, "total_pages": total_pages, "total_groups": total_groups})
         return paginator.get_paginated_response(serializer.data)
 
 

--- a/apps/studies/views/groups.py
+++ b/apps/studies/views/groups.py
@@ -1,16 +1,17 @@
-from typing import Any
+from typing import Any, List, cast
 
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import parsers, status
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from ..models.groups import StudyGroup
 from ..paginations import StudyGroupPagination
+from ..permissions import IsGroupLeader
 from ..serializers.groups import (
     StudyGroupCreateSerializer,
     StudyGroupDetailSerializer,
@@ -65,9 +66,14 @@ class StudyGroupListCreateView(APIView):
 
 
 class StudyGroupDetailUpdateView(APIView):
-    permission_classes = [IsAuthenticated]
-
     parser_classes = [parsers.JSONParser, parsers.MultiPartParser]
+
+    def get_permissions(self) -> List[BasePermission]:
+        if self.request.method == "GET":
+            return [IsAuthenticated()]
+        if self.request.method == "PUT":
+            return [IsAuthenticated(), IsGroupLeader()]
+        return cast(List[BasePermission], super().get_permissions())
 
     @extend_schema(
         operation_id="v1_studies_groups_detail",

--- a/apps/studies/views/groups.py
+++ b/apps/studies/views/groups.py
@@ -64,7 +64,9 @@ class StudyGroupListCreateView(APIView):
 
         paginator = self.pagination_class()
         page = paginator.paginate_queryset(queryset, self.request)
-        serializer = StudyGroupListSerializer(page, many=True, context={"request": request, "total_pages": total_pages, "total_groups": total_groups})
+        serializer = StudyGroupListSerializer(
+            page, many=True, context={"request": request, "total_pages": total_pages, "total_groups": total_groups}
+        )
         return paginator.get_paginated_response(serializer.data)
 
 


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 스터디 그룹 CRU API 코드 수정 및 프론트 요구사항 반영

## 📄 상세 내용
- [ ] DateTimeField 응답 형식 %Y-%m-%d %H:%M:%S 로 변경
- [ ] 그룹 목록 조회에 total_pages, total_groups 필드 추가
- [ ] 그룹 상세 조회에 요청한 유저가 리더인지 나타내는 is_me_leader 필드 추가
- [ ] 그룹 상세 조회, 수정 API의 권한 검증 로직 추가
- [ ] 리더 권한 확인 퍼미션 로직 추가
---------------
- [ ] total_pages, total_groups를 시리얼라이저가 아닌 뷰에서 계산해 context로 받게 변경
## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
