### PR TITLE
💡 chore    : attachments mock 코드 포맷 및 변수 일관성 정리

### DIFF
--- a/apps/recruitments/views/attachment.py
+++ b/apps/recruitments/views/attachment.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import timedelta
 from typing import Any
 
@@ -24,7 +23,7 @@ class AttachmentListCreateAPIView(APIView):
     permission_classes = [AllowAny]
     parser_classes = [parsers.JSONParser, parsers.MultiPartParser]
 
-    # Mock 제약(중복/존재하지 않음) — 팀의 Bookmark 패턴과 동일하게 유지
+    # Mock 제약(중복/존재하지 않음)
     MOCK_DUPLICATE_URLS = {
         "https://cdn.example.com/files/dup1.pdf",
         "https://cdn.example.com/files/dup2.pdf",
@@ -38,27 +37,32 @@ class AttachmentListCreateAPIView(APIView):
         operation_id="v1_attachments_list",
     )
     def get(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
-        # Mock 데이터: 실제 DB 접근 없이 모델 인스턴스를 메모리에 구성 (팀 패턴과 동일)
+        base_now = timezone.now()
         mock_data = [
             RecruitmentAttachment(
                 id=i,
                 recruitment_id=recruitment_id,
                 file_url=f"https://cdn.example.com/files/mock_{i}.pdf",
                 file_name=f"Mock 파일 {i}.pdf",
-                created_at=timezone.now() - timedelta(days=i),
-                updated_at=timezone.now(),
+                created_at=base_now - timedelta(days=i),
+                updated_at=base_now,
             )
             for i in range(1, 16)
         ]
-        serializer = self.serializer_class(mock_data, many=True)
 
-        # 수동 페이지네이션 (Bookmark와 동일한 10개 페이징)
-        page = int(request.query_params.get("page", 1))
+        try:
+            page = int(request.query_params.get("page", 1))
+            if page < 1:
+                page = 1
+        except (TypeError, ValueError):
+            page = 1
+
         page_size = 10
         start, end = (page - 1) * page_size, (page - 1) * page_size + page_size
-        paged_data = serializer.data[start:end]
+        page_objs = mock_data[start:end]
+        serializer = self.serializer_class(page_objs, many=True)
 
-        return Response({"results": paged_data}, status=status.HTTP_200_OK)
+        return Response({"results": serializer.data}, status=status.HTTP_200_OK)
 
     @extend_schema(
         tags=["Attachments"],
@@ -70,26 +74,28 @@ class AttachmentListCreateAPIView(APIView):
     def post(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
         data = request.data
 
-        # recruitment 유효성 (Mock)
         if recruitment_id in self.MOCK_NONEXISTENT_RECRUITMENT_IDS:
             return Response({"detail": "존재하지 않는 공고입니다."}, status=status.HTTP_404_NOT_FOUND)
 
-        # 중복 URL 체크 (Mock)
-        if (url := data.get("file_url")) in self.MOCK_DUPLICATE_URLS:
+        url = data.get("file_url")
+        if isinstance(url, str):
+            url = url.strip()
+            data["file_url"] = url
+
+        if url in self.MOCK_DUPLICATE_URLS:
             return Response({"detail": "이미 등록된 첨부파일입니다."}, status=status.HTTP_400_BAD_REQUEST)
 
-        # 스키마 일치 및 유효성 확인 (Mock이지만 팀 코드와 동일하게 serializer.is_valid 사용)
         serializer = self.serializer_class(data=data)
         serializer.is_valid(raise_exception=True)
 
-        # 생성 결과(Mock) — id만 임의 값으로 반환
+        base_now = timezone.now()
         created = RecruitmentAttachment(
-            id=uuid.uuid4().int % 100000,  # 임의 id
+            id=1,  # uuid 대신 고정 id
             recruitment_id=recruitment_id,
             file_url=serializer.validated_data["file_url"],
             file_name=serializer.validated_data["file_name"],
-            created_at=timezone.now(),
-            updated_at=timezone.now(),
+            created_at=base_now,
+            updated_at=base_now,
         )
         return Response(self.serializer_class(created).data, status=status.HTTP_201_CREATED)
 
@@ -111,13 +117,14 @@ class AttachmentRetrieveDestroyAPIView(APIView):
         operation_id="v1_attachments_retrieve",
     )
     def get(self, request: Request, attachment_id: int, *args: Any, **kwargs: Any) -> Response:
+        base_now = timezone.now()
         mock = RecruitmentAttachment(
             id=attachment_id,
             recruitment_id=1,
             file_url=f"https://cdn.example.com/files/mock_{attachment_id}.pdf",
             file_name=f"Mock 파일 {attachment_id}.pdf",
-            created_at=timezone.now() - timedelta(days=1),
-            updated_at=timezone.now(),
+            created_at=base_now - timedelta(days=1),
+            updated_at=base_now,
         )
         return Response(self.serializer_class(mock).data, status=status.HTTP_200_OK)
 
@@ -127,5 +134,4 @@ class AttachmentRetrieveDestroyAPIView(APIView):
         operation_id="v1_attachments_destroy",
     )
     def delete(self, request: Request, attachment_id: int, *args: Any, **kwargs: Any) -> Response:
-        # 팀 코드 스타일에 맞춰 204와 메시지를 함께 반환
         return Response({"detail": "첨부파일이 삭제되었습니다."}, status=status.HTTP_200_OK)


### PR DESCRIPTION
💡 chore    : attachments mock 코드 포맷 및 변수 일관성 정리

1. timezone.now()을 여러번 호출하는게 아니고 base_now 변수에 저장 -> 호출 시 시간이 달리질 수 있어서 일관성 유지
2. 전체 직렬화 후 슬라이싱을 슬라이싱 후 직렬화 -> 불필요한 직렬화 제거
3. uuid -> id=1 으로 변경
4. page 값 예외 처리 추가 -> 잘못된 쿼리 파라미터 입력시 500 방지
5. file_url.strip()추가 -> 공백 제거로 중복 검사 정확도 향상

## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 어떤 작업을 했는지 간단하게 적어주세요.

## 📄 상세 내용
- [x] 주요 변경 사항 1
- [x] 주요 변경 사항 2
- [x] 주요 변경 사항 3

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
