### PR TITLE
[Feature/users profile/juhyun] 프로필 이미지 수정시 S3에 이미지 업로드 & 기존 이미지 삭제

### DIFF
--- a/apps/users/serializers/user_profile_serializers.py
+++ b/apps/users/serializers/user_profile_serializers.py
@@ -47,11 +47,11 @@ class UserProfileUpdateSerializer(serializers.ModelSerializer[Any]):
         validators=[validate_korean_phone],
     )
     phone_verify_token = serializers.CharField(write_only=True, required=False)
+    profile_img = serializers.ImageField(required=False, allow_empty_file=False)
 
     class Meta:
         model = User
-        fields = ("nickname", "profile_img_url", "phone_number", "phone_verify_token")
-        extra_kwargs = {"profile_img_url": {"required": False}}
+        fields = ("nickname", "profile_img", "phone_number", "phone_verify_token")
 
 
 class UserProfileUpdateResponseSerializer(serializers.ModelSerializer[Any]):

--- a/apps/users/services/user_profile_services.py
+++ b/apps/users/services/user_profile_services.py
@@ -82,7 +82,9 @@ def update_user_profile(
         ext = str(profile_img.name).rsplit(".", 1)[-1].lower()
         S3Uploader.validate_file_mime(ext, content_type)
 
-        prefix = f"profiles/{user.uuid}"
+        prefix = f"profiles/"
+        profile_img.name = f"{user.uuid}_{profile_img.name}"  # 파일명 앞에 uuid 붙여서 구분
+
         new_profile_url = S3Uploader.upload_file(profile_img, prefix=prefix)
         uploaded_new_key = _extract_key_from_url(new_profile_url)
 

--- a/apps/users/services/user_profile_services.py
+++ b/apps/users/services/user_profile_services.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+import logging
+from typing import TYPE_CHECKING, Any, Optional
 
 from django.contrib.auth import get_user_model, password_validation
 from django.contrib.auth.hashers import check_password
@@ -9,6 +10,7 @@ from django.db import transaction
 from rest_framework.exceptions import ValidationError
 
 from apps.core.exceptions import Conflict
+from apps.core.utils.s3_uploader import S3Uploader
 from apps.users.enums import PhoneVerificationPurpose
 from apps.users.utils.verify_token import verify_and_consume  # Response | dict
 
@@ -17,12 +19,21 @@ if TYPE_CHECKING:
 
 User = get_user_model()
 
+logger = logging.getLogger(__name__)
+
+
+def _extract_key_from_url(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    base = S3Uploader.S3_BASE_URL
+    return url[len(base) :] if url.startswith(base) else None
+
 
 def update_user_profile(
     *,
     user: UserModel,
     nickname: Optional[str],
-    profile_img_url: Optional[str],
+    profile_img: Optional[Any],
     phone_number: Optional[str],
     phone_verify_token: Optional[str],
 ) -> UserModel:
@@ -57,11 +68,59 @@ def update_user_profile(
         if User.objects.exists_phone(phone_number):
             raise Conflict({"error": "이미 사용 중인 휴대폰 번호입니다."})
 
-    with transaction.atomic():
-        user.nickname = nickname if nickname is not None else user.nickname
-        user.profile_img_url = profile_img_url if profile_img_url is not None else user.profile_img_url
-        user.phone_number = phone_number if phone_number is not None else user.phone_number
-        user.save(update_fields=["nickname", "profile_img_url", "phone_number"])
+    # 새 이미지가 있다면, 우선 업로드
+    new_profile_url: Optional[str] = None
+    uploaded_new_key: Optional[str] = None
+    old_key_to_delete: Optional[str] = None
+
+    if profile_img is not None:
+        # 파일 유효성 검증
+        S3Uploader.validate_file_name(profile_img)
+        S3Uploader.validate_file_extension(profile_img)
+        content_type = getattr(profile_img, "content_type", None)
+        S3Uploader.validate_file_content_type(content_type)
+        ext = str(profile_img.name).rsplit(".", 1)[-1].lower()
+        S3Uploader.validate_file_mime(ext, content_type)
+
+        prefix = f"profiles/{user.uuid}"
+        new_profile_url = S3Uploader.upload_file(profile_img, prefix=prefix)
+        uploaded_new_key = _extract_key_from_url(new_profile_url)
+
+        # 기존 이미지 키(삭제 후보)
+        old_key_to_delete = _extract_key_from_url(user.profile_img_url) if new_profile_url else None
+
+    try:
+        with transaction.atomic():
+            update_fields: list[str] = []
+
+            if nickname is not None:
+                user.nickname = nickname
+                update_fields.append("nickname")
+            if new_profile_url is not None:
+                user.profile_img_url = new_profile_url
+                update_fields.append("profile_img_url")
+            if phone_number is not None:
+                user.phone_number = phone_number
+                update_fields.append("phone_number")
+            # 변경된 필드만 저장
+            if update_fields:
+                user.save(update_fields=update_fields)
+    except Exception:
+        # DB 저장 실패시 새로 올린 이미지 보상 삭제
+        if uploaded_new_key:
+            try:
+                S3Uploader.delete_file(uploaded_new_key)
+            except Exception:
+                logger.exception("보상 삭제 실패(신규 프로필 이미지)")
+        raise
+
+    # 커밋 성공 후 기존 이미지 삭제
+    if old_key_to_delete:
+        try:
+            S3Uploader.delete_file(old_key_to_delete)
+        except Exception:
+            logger.exception("기존 프로필 이미지 삭제 실패")
+
     return user
 
 

--- a/apps/users/tests/test_user_profile_update.py
+++ b/apps/users/tests/test_user_profile_update.py
@@ -57,17 +57,16 @@ class UserProfileUpdateTests(IsolatedRedisTestClient):
         body = resp.json()
         self.assertIn("detail", body)
 
-    def test_update_basic_fields_success(self) -> None:
+    def test_update_nickname_success(self) -> None:
         """
-        닉네임/프로필이미지만 수정 성공
+        닉네임만 변경 성공
         """
-        payload = {"nickname": "new_nick", "profile_img_url": "https://img.example.com/a.png"}
-        resp = self.client.patch(self.url, payload, format="json")
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        body = resp.json()
+        payload = {"nickname": "new_nick"}
+        response = self.client.patch(self.url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
         self.assertEqual(body["detail"], "내 정보가 수정되었습니다.")
         self.assertEqual(body["data"]["nickname"], "new_nick")
-        self.assertEqual(body["data"]["profile_img_url"], "https://img.example.com/a.png")
 
     def test_nickname_validator_digits_only(self) -> None:
         """

--- a/apps/users/tests/test_user_profile_update.py
+++ b/apps/users/tests/test_user_profile_update.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Any
+from io import BytesIO
+from typing import Any, Literal, cast
 from unittest.mock import patch
 
+import boto3
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
+from moto import mock_aws
+from PIL import Image
 from rest_framework import status
 
 from apps.core.utils.isolated_cache_testcase import IsolatedRedisTestClient
+from apps.core.utils.s3_uploader import S3Uploader
 from apps.users.enums import Gender, PhoneVerificationPurpose
 from apps.users.utils.verify_token import issue_verify_token
 
@@ -186,6 +193,116 @@ class UserProfileUpdateTests(IsolatedRedisTestClient):
         resp = self.client.patch(self.url, {"nickname": self.other.nickname}, format="json")
         self.assertEqual(resp.status_code, status.HTTP_409_CONFLICT)
         self.assertEqual(resp.json().get("error"), "이미 사용 중인 닉네임입니다.")
+
+    # --- moto S3 helper (이미지 테스트에서만 사용) ---
+    _moto:Any = None
+    bucket: str
+    region: str
+
+    def _start_s3_mock(self) -> None:
+        self._moto = mock_aws()
+        self._moto.start()
+
+        self.bucket = "test-bucket"
+        self.region = "ap-northeast-2"
+
+        # settings 및 moto 클라이언트 준비
+        setattr(settings, "AWS_S3_BUCKET_NAME", self.bucket)
+        setattr(settings, "AWS_S3_REGION", self.region)
+        setattr(settings, "AWS_S3_ACCESS_KEY_ID", "xxx")
+        setattr(settings, "AWS_S3_SECRET_ACCESS_KEY", "yyy")
+
+        s3 = boto3.client("s3", region_name=self.region)
+        s3.create_bucket(
+            Bucket=self.bucket,
+            CreateBucketConfiguration={"LocationConstraint": cast(Literal["ap-northeast-2"], self.region)},
+        )
+
+        # S3Uploader를 moto 클라이언트로 바인딩
+        S3Uploader.BUCKET_NAME = self.bucket
+        S3Uploader.REGION_NAME = self.region
+        S3Uploader.s3_client = s3
+        S3Uploader.S3_BASE_URL = f"https://{self.bucket}.s3.{self.region}.amazonaws.com/"
+
+    def _stop_s3_mock(self) -> None:
+        if self._moto:
+            self._moto.stop()
+            self._moto = None
+
+    # --- (1) 프로필 이미지 업로드 성공 ---
+    def test_update_profile_image_only_success(self) -> None:
+        """
+        프로필 이미지 변경 성공 (닉네임/휴대폰 변경 없음)
+        """
+        self._start_s3_mock()
+        try:
+            buf = BytesIO()
+            Image.new("RGB", (1, 1), (255, 0, 0)).save(buf, format="PNG")  # 진짜 PNG
+            buf.seek(0)
+
+            img = SimpleUploadedFile("avatar.png", buf.getvalue(), content_type="image/png")
+            resp = self.client.patch(self.url, {"profile_img": img}, format="multipart")
+
+            self.assertEqual(resp.status_code, status.HTTP_200_OK, msg=resp.content)
+            body = resp.json()
+            self.assertEqual(body["detail"], "내 정보가 수정되었습니다.")
+            new_url = body["data"]["profile_img_url"]
+            self.assertTrue(new_url.startswith(S3Uploader.S3_BASE_URL))
+
+            # moto S3에 실제 객체 존재 확인
+            new_key = new_url.replace(S3Uploader.S3_BASE_URL, "")
+            head = S3Uploader.s3_client.head_object(Bucket=S3Uploader.BUCKET_NAME, Key=new_key)
+            self.assertEqual(head["ResponseMetadata"]["HTTPStatusCode"], 200)
+        finally:
+            self._stop_s3_mock()
+
+    # --- (2) 기존 이미지가 있을 때 교체 → 기존 이미지 삭제 확인 ---
+    def test_update_profile_image_replaces_old(self) -> None:
+        """
+        기존 이미지가 있을 때 새 이미지로 교체 시, 커밋 후 기존 이미지가 S3에서 삭제된다.
+        """
+        self._start_s3_mock()
+        try:
+            buf = BytesIO()
+            Image.new("RGB", (1, 1), (255, 0, 0)).save(buf, format="PNG")  # 진짜 PNG
+            buf.seek(0)
+            img_bytes = buf.getvalue()
+
+            # 기존 이미지 주입 + URL 세팅
+            old_key = f"profiles/{self.me.id}/old.png"
+            S3Uploader.s3_client.put_object(
+                Bucket=S3Uploader.BUCKET_NAME,
+                Key=old_key,
+                Body=img_bytes,
+                ACL="public-read",
+            )
+
+            self.me.profile_img_url = S3Uploader.S3_BASE_URL + old_key
+            self.me.save(update_fields=["profile_img_url"])
+
+            # 새 이미지 업로드
+            buf2 = BytesIO()
+            Image.new("RGB", (1, 1), (255, 0, 0)).save(buf2, format="PNG")
+            buf2.seek(0)
+            new_img = SimpleUploadedFile("avatar2.png", buf2.getvalue(), content_type="image/png")
+
+            resp = self.client.patch(self.url, {"profile_img": new_img}, format="multipart")
+            self.assertEqual(resp.status_code, status.HTTP_200_OK, msg=resp.content)
+
+            body = resp.json()
+            new_url = body["data"]["profile_img_url"]
+            self.assertTrue(new_url.startswith(S3Uploader.S3_BASE_URL))
+            new_key = new_url.replace(S3Uploader.S3_BASE_URL, "")
+
+            # 새 객체는 존재
+            head_new = S3Uploader.s3_client.head_object(Bucket=S3Uploader.BUCKET_NAME, Key=new_key)
+            self.assertEqual(head_new["ResponseMetadata"]["HTTPStatusCode"], 200)
+
+            # 기존 객체는 삭제되었는지 확인(존재 조회 시 예외)
+            with self.assertRaises(Exception):
+                S3Uploader.s3_client.head_object(Bucket=S3Uploader.BUCKET_NAME, Key=old_key)
+        finally:
+            self._stop_s3_mock()
 
 
 class ChangePasswordAPITests(IsolatedRedisTestClient):

--- a/apps/users/tests/test_user_profile_update.py
+++ b/apps/users/tests/test_user_profile_update.py
@@ -195,7 +195,7 @@ class UserProfileUpdateTests(IsolatedRedisTestClient):
         self.assertEqual(resp.json().get("error"), "이미 사용 중인 닉네임입니다.")
 
     # --- moto S3 helper (이미지 테스트에서만 사용) ---
-    _moto:Any = None
+    _moto: Any = None
     bucket: str
     region: str
 

--- a/apps/users/views/user_profile_views.py
+++ b/apps/users/views/user_profile_views.py
@@ -4,6 +4,7 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serial
 from rest_framework import serializers, status
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import NotAuthenticated
+from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -101,6 +102,8 @@ class MeView(APIView):
 
 
 class UserProfileUpdateView(APIView):
+    parser_classes = [MultiPartParser, JSONParser]
+
     @extend_schema(
         tags=["Users"],
         summary="내 정보 수정 - 일반정보 수정 ",
@@ -126,7 +129,7 @@ class UserProfileUpdateView(APIView):
         updated = update_user_profile(
             user=request.user,
             nickname=req_serializer.validated_data.get("nickname"),
-            profile_img_url=req_serializer.validated_data.get("profile_img_url"),
+            profile_img=req_serializer.validated_data.get("profile_img"),
             phone_number=req_serializer.validated_data.get("phone_number"),
             phone_verify_token=req_serializer.validated_data.get("phone_verify_token"),
         )


### PR DESCRIPTION
## ✅ PR 요약
- 프로필 이미지 수정시 S3에 이미지 업로드 & 기존 이미지 삭제

## 📄 상세 내용
- [x] 프로필 업데이트 API에 프로필 이미지 수정시 s3에 이미지 업로드 & 기존 이미지 삭제 로직 추가
- [x] 관련 테스트 코드 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
