### PR TITLE
Feature/recruitments  admin 기능(recm12~recm15)

### DIFF
--- a/apps/recruitments/models/__init__.py
+++ b/apps/recruitments/models/__init__.py
@@ -17,3 +17,7 @@ __all__ = [
     "RecruitmentSearchLog",
     "Tag",
 ]
+
+
+class Application:
+    pass

--- a/apps/recruitments/serializers/admin_serializers.py
+++ b/apps/recruitments/serializers/admin_serializers.py
@@ -6,6 +6,7 @@ from apps.recruitments.models.application import Application
 
 class AdminRecruitmentTagSerializer(serializers.ModelSerializer[Tag]):
     """관리자용 태그"""
+
     id = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -15,6 +16,7 @@ class AdminRecruitmentTagSerializer(serializers.ModelSerializer[Tag]):
 
 class AdminRecruitmentAttachmentSerializer(serializers.ModelSerializer[RecruitmentAttachment]):
     """관리자용 첨부파일"""
+
     id = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -24,6 +26,7 @@ class AdminRecruitmentAttachmentSerializer(serializers.ModelSerializer[Recruitme
 
 class AdminApplicationSerializer(serializers.ModelSerializer[Application]):
     """관리자용 지원내역"""
+
     id = serializers.IntegerField(read_only=True)  #
     nickname = serializers.CharField(source="user.nickname", read_only=True)
     email = serializers.EmailField(source="user.email", read_only=True)
@@ -37,9 +40,8 @@ class AdminApplicationSerializer(serializers.ModelSerializer[Application]):
 
 class AdminRecruitmentListSerializer(serializers.ModelSerializer[Recruitment]):
     """관리자용 공고 목록"""
-    tags: serializers.SlugRelatedField[Tag] = serializers.SlugRelatedField(
-        slug_field="name", read_only=True, many=True
-    )
+
+    tags: serializers.SlugRelatedField[Tag] = serializers.SlugRelatedField(slug_field="name", read_only=True, many=True)
     status = serializers.SerializerMethodField()
     bookmark_count = serializers.SerializerMethodField()
     applications = AdminApplicationSerializer(many=True, read_only=True)
@@ -71,6 +73,7 @@ class AdminRecruitmentListSerializer(serializers.ModelSerializer[Recruitment]):
 
 class AdminRecruitmentDetailSerializer(serializers.ModelSerializer[Recruitment]):
     """관리자용 공고 상세"""
+
     attachments = AdminRecruitmentAttachmentSerializer(many=True, read_only=True)
     tags = AdminRecruitmentTagSerializer(many=True, read_only=True)
     applications = AdminApplicationSerializer(many=True, read_only=True)

--- a/apps/recruitments/serializers/admin_serializers.py
+++ b/apps/recruitments/serializers/admin_serializers.py
@@ -5,21 +5,26 @@ from apps.recruitments.models.application import Application
 
 
 class AdminRecruitmentTagSerializer(serializers.ModelSerializer[Tag]):
-    # 관리자용 태그
+    """관리자용 태그"""
+    id = serializers.IntegerField(read_only=True)
+
     class Meta:
         model = Tag
-        fields = ["name"]
+        fields = ["id", "name"]
 
 
 class AdminRecruitmentAttachmentSerializer(serializers.ModelSerializer[RecruitmentAttachment]):
-    # 관리자용 첨부파일
+    """관리자용 첨부파일"""
+    id = serializers.IntegerField(read_only=True)
+
     class Meta:
         model = RecruitmentAttachment
-        fields = ["file_name", "file_url"]
+        fields = ["id", "file_name", "file_url"]
 
 
 class AdminApplicationSerializer(serializers.ModelSerializer[Application]):
-    # 관리자용 지원내역
+    """관리자용 지원내역"""
+    id = serializers.IntegerField(read_only=True)  #
     nickname = serializers.CharField(source="user.nickname", read_only=True)
     email = serializers.EmailField(source="user.email", read_only=True)
     applied_at = serializers.DateTimeField(source="created_at", read_only=True)
@@ -27,12 +32,14 @@ class AdminApplicationSerializer(serializers.ModelSerializer[Application]):
 
     class Meta:
         model = Application
-        fields = ["nickname", "email", "applied_at", "status", "status_display"]
+        fields = ["id", "nickname", "email", "applied_at", "status", "status_display"]
 
 
 class AdminRecruitmentListSerializer(serializers.ModelSerializer[Recruitment]):
-    # 관리자용 공고 목록
-    tags: serializers.SlugRelatedField[Tag] = serializers.SlugRelatedField(slug_field="name", read_only=True, many=True)
+    """관리자용 공고 목록"""
+    tags: serializers.SlugRelatedField[Tag] = serializers.SlugRelatedField(
+        slug_field="name", read_only=True, many=True
+    )
     status = serializers.SerializerMethodField()
     bookmark_count = serializers.SerializerMethodField()
     applications = AdminApplicationSerializer(many=True, read_only=True)
@@ -54,14 +61,16 @@ class AdminRecruitmentListSerializer(serializers.ModelSerializer[Recruitment]):
         ]
 
     def get_status(self, obj: Recruitment) -> str:
+        """공고 상태 (모집중 / 마감)"""
         return "마감" if obj.is_closed else "모집중"
 
     def get_bookmark_count(self, obj: Recruitment) -> int:
+        """북마크 개수 반환"""
         return getattr(obj, "bookmark_count", 0)
 
 
 class AdminRecruitmentDetailSerializer(serializers.ModelSerializer[Recruitment]):
-    # 관리자용 공고 상세
+    """관리자용 공고 상세"""
     attachments = AdminRecruitmentAttachmentSerializer(many=True, read_only=True)
     tags = AdminRecruitmentTagSerializer(many=True, read_only=True)
     applications = AdminApplicationSerializer(many=True, read_only=True)
@@ -88,5 +97,5 @@ class AdminRecruitmentDetailSerializer(serializers.ModelSerializer[Recruitment])
         ]
 
     def get_bookmark_count(self, obj: Recruitment) -> int:
-        # SerializerMethodField를 명시적으로 반환만 수행
+        """SerializerMethodField 명시적 반환"""
         return getattr(obj, "bookmark_count", 0)

--- a/apps/recruitments/serializers/admin_serializers.py
+++ b/apps/recruitments/serializers/admin_serializers.py
@@ -1,15 +1,71 @@
 from rest_framework import serializers
 
-from apps.recruitments.models import Recruitment
-from apps.recruitments.serializers.tag import TagSerializer
+from apps.recruitments.models import Recruitment, RecruitmentAttachment, Tag
+from apps.recruitments.models.application import Application
 
 
-class AdminRecruitmentSerializer(serializers.ModelSerializer[Recruitment]):
-    """관리자용 구인 공고 목록/상세 Serializer"""
+class AdminRecruitmentTagSerializer(serializers.ModelSerializer[Tag]):
+    # 관리자용 태그
+    class Meta:
+        model = Tag
+        fields = ["name"]
 
-    tags = TagSerializer(many=True, read_only=True)
-    author_nickname = serializers.CharField(source="author.nickname", read_only=True)
-    study_group_name = serializers.CharField(source="study_group.name", read_only=True, allow_null=True)
+
+class AdminRecruitmentAttachmentSerializer(serializers.ModelSerializer[RecruitmentAttachment]):
+    # 관리자용 첨부파일
+    class Meta:
+        model = RecruitmentAttachment
+        fields = ["file_name", "file_url"]
+
+
+class AdminApplicationSerializer(serializers.ModelSerializer[Application]):
+    # 관리자용 지원내역
+    nickname = serializers.CharField(source="user.nickname", read_only=True)
+    email = serializers.EmailField(source="user.email", read_only=True)
+    applied_at = serializers.DateTimeField(source="created_at", read_only=True)
+    status_display = serializers.CharField(source="get_status_display", read_only=True)
+
+    class Meta:
+        model = Application
+        fields = ["nickname", "email", "applied_at", "status", "status_display"]
+
+
+class AdminRecruitmentListSerializer(serializers.ModelSerializer[Recruitment]):
+    # 관리자용 공고 목록
+    tags: serializers.SlugRelatedField[Tag] = serializers.SlugRelatedField(slug_field="name", read_only=True, many=True)
+    status = serializers.SerializerMethodField()
+    bookmark_count = serializers.SerializerMethodField()
+    applications = AdminApplicationSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Recruitment
+        fields = [
+            "id",
+            "title",
+            "tags",
+            "is_closed",
+            "close_at",
+            "status",
+            "views_count",
+            "bookmark_count",
+            "created_at",
+            "updated_at",
+            "applications",
+        ]
+
+    def get_status(self, obj: Recruitment) -> str:
+        return "마감" if obj.is_closed else "모집중"
+
+    def get_bookmark_count(self, obj: Recruitment) -> int:
+        return getattr(obj, "bookmark_count", 0)
+
+
+class AdminRecruitmentDetailSerializer(serializers.ModelSerializer[Recruitment]):
+    # 관리자용 공고 상세
+    attachments = AdminRecruitmentAttachmentSerializer(many=True, read_only=True)
+    tags = AdminRecruitmentTagSerializer(many=True, read_only=True)
+    applications = AdminApplicationSerializer(many=True, read_only=True)
+    bookmark_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Recruitment
@@ -18,21 +74,19 @@ class AdminRecruitmentSerializer(serializers.ModelSerializer[Recruitment]):
             "uuid",
             "title",
             "content",
-            "estimated_fee",
+            "attachments",
             "expected_headcount",
-            "views_count",
+            "estimated_fee",
+            "tags",
             "close_at",
             "is_closed",
             "created_at",
             "updated_at",
-            "author_nickname",
-            "study_group_name",
-            "tags",
+            "views_count",
+            "bookmark_count",
+            "applications",
         ]
 
-
-class AdminRecruitmentDetailSerializer(AdminRecruitmentSerializer):
-    """관리자용 구인 공고 상세 Serializer"""
-
-    class Meta(AdminRecruitmentSerializer.Meta):
-        pass
+    def get_bookmark_count(self, obj: Recruitment) -> int:
+        # SerializerMethodField를 명시적으로 반환만 수행
+        return getattr(obj, "bookmark_count", 0)

--- a/apps/recruitments/serializers/admin_serializers.py
+++ b/apps/recruitments/serializers/admin_serializers.py
@@ -1,0 +1,38 @@
+from rest_framework import serializers
+
+from apps.recruitments.models import Recruitment
+from apps.recruitments.serializers.tag import TagSerializer
+
+
+class AdminRecruitmentSerializer(serializers.ModelSerializer[Recruitment]):
+    """관리자용 구인 공고 목록/상세 Serializer"""
+
+    tags = TagSerializer(many=True, read_only=True)
+    author_nickname = serializers.CharField(source="author.nickname", read_only=True)
+    study_group_name = serializers.CharField(source="study_group.name", read_only=True, allow_null=True)
+
+    class Meta:
+        model = Recruitment
+        fields = [
+            "id",
+            "uuid",
+            "title",
+            "content",
+            "estimated_fee",
+            "expected_headcount",
+            "views_count",
+            "close_at",
+            "is_closed",
+            "created_at",
+            "updated_at",
+            "author_nickname",
+            "study_group_name",
+            "tags",
+        ]
+
+
+class AdminRecruitmentDetailSerializer(AdminRecruitmentSerializer):
+    """관리자용 구인 공고 상세 Serializer"""
+
+    class Meta(AdminRecruitmentSerializer.Meta):
+        pass

--- a/apps/recruitments/tests/test_admin_recruitments_api.py
+++ b/apps/recruitments/tests/test_admin_recruitments_api.py
@@ -10,8 +10,12 @@ from apps.users.models import User
 
 
 class AdminRecruitmentAPITestCase(TestCase):
+    # 관리자용 스터디 구인공고 API 테스트
     def setUp(self) -> None:
+        # APIClient 타입 명시
         self.client: APIClient = APIClient()
+
+        # 관리자 계정 및 기본 공고 생성
         self.admin_user = User.objects.create_superuser(
             email="admin@test.com",
             password="admin1234",
@@ -30,34 +34,72 @@ class AdminRecruitmentAPITestCase(TestCase):
             views_count=15,
         )
 
-    def test_admin_list_recruitments(self) -> None:
+    # 목록 조회
+    def test_admin_can_list_recruitments(self) -> None:
+        # 관리자가 전체 공고 목록을 조회할 수 있는지 확인
         url = reverse("admin_recruitment_list")
         res = self.client.get(url)
-        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.status_code, status.HTTP_200_OK, "목록 조회 응답 코드가 올바르지 않음")
         self.assertEqual(res.json()[0]["title"], "테스트 공고")
 
-    def test_admin_filter_by_is_closed(self) -> None:
+    def test_admin_can_filter_closed_recruitments(self) -> None:
+        # 마감된 공고만 반환되는지 확인
         self.recruitment.is_closed = True
         self.recruitment.save()
         url = f"{reverse('admin_recruitment_list')}?is_closed=true"
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         for item in res.json():
-            self.assertTrue(item["is_closed"])
+            self.assertTrue(item["is_closed"], "마감된 공고만 반환되지 않음")
 
-    def test_admin_retrieve_recruitment(self) -> None:
+    def test_admin_can_filter_open_recruitments(self) -> None:
+        # 진행 중인 공고만 반환되는지 확인
+        url = f"{reverse('admin_recruitment_list')}?is_closed=false"
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        for item in res.json():
+            self.assertFalse(item["is_closed"], "진행 중 공고만 반환되지 않음")
+
+    def test_admin_can_filter_by_tag_name(self) -> None:
+        # 태그명으로 필터링 시 정상 응답 확인
+        url = f"{reverse('admin_recruitment_list')}?tag=테스트"
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    # 상세 조회
+    def test_admin_can_retrieve_recruitment_detail(self) -> None:
+        # 관리자가 특정 공고 상세 정보를 조회할 수 있는지 확인
         url = reverse("admin_recruitment_detail", args=[self.recruitment.id])
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.json()["title"], "테스트 공고")
 
-    def test_admin_delete_recruitment(self) -> None:
+    def test_retrieve_nonexistent_recruitment_returns_404(self) -> None:
+        # 존재하지 않는 공고 조회 시 404 응답 반환 확인
+        url = reverse("admin_recruitment_detail", args=[9999])
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    # 삭제
+    def test_admin_can_delete_recruitment(self) -> None:
+        # 관리자가 공고를 정상적으로 삭제할 수 있는지 확인
         url = reverse("admin_recruitment_detail", args=[self.recruitment.id])
         res = self.client.delete(url)
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(Recruitment.objects.filter(id=self.recruitment.id).exists())
+        self.assertFalse(
+            Recruitment.objects.filter(id=self.recruitment.id).exists(),
+            "삭제 이후에도 공고가 존재함",
+        )
 
-    def test_non_admin_forbidden(self) -> None:
+    def test_delete_nonexistent_recruitment_returns_404(self) -> None:
+        # 존재하지 않는 공고 삭제 시 404 응답 반환 확인
+        url = reverse("admin_recruitment_detail", args=[9999])
+        res = self.client.delete(url)
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    # 권한
+    def test_non_admin_cannot_access_admin_endpoints(self) -> None:
+        # 일반 유저가 관리자용 엔드포인트 접근 시 403 응답 확인
         user = User.objects.create_user(
             email="user@test.com",
             password="1234",
@@ -69,23 +111,3 @@ class AdminRecruitmentAPITestCase(TestCase):
         url = reverse("admin_recruitment_list")
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_admin_filter_by_tag_name(self) -> None:
-        url = f"{reverse('admin_recruitment_list')}?tag=테스트"
-        res = self.client.get(url)
-        self.assertEqual(res.status_code, status.HTTP_200_OK)
-
-    def test_admin_filter_by_is_closed_false(self) -> None:
-        url = f"{reverse('admin_recruitment_list')}?is_closed=false"
-        res = self.client.get(url)
-        self.assertEqual(res.status_code, status.HTTP_200_OK)
-
-    def test_admin_retrieve_nonexistent_recruitment(self) -> None:
-        url = reverse("admin_recruitment_detail", args=[9999])
-        res = self.client.get(url)
-        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_admin_delete_nonexistent_recruitment(self) -> None:
-        url = reverse("admin_recruitment_detail", args=[9999])
-        res = self.client.delete(url)
-        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)

--- a/apps/recruitments/tests/test_admin_recruitments_api.py
+++ b/apps/recruitments/tests/test_admin_recruitments_api.py
@@ -5,17 +5,17 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.recruitments.models import Recruitment
+from apps.recruitments.models import Recruitment, Tag
 from apps.users.models import User
 
 
 class AdminRecruitmentAPITestCase(TestCase):
-    # 관리자용 스터디 구인공고 API 테스트
+    """관리자용 스터디 구인공고 API 통합 테스트"""
+
     def setUp(self) -> None:
-        # APIClient 타입 명시
         self.client: APIClient = APIClient()
 
-        # 관리자 계정 및 기본 공고 생성
+        # 관리자 생성
         self.admin_user = User.objects.create_superuser(
             email="admin@test.com",
             password="admin1234",
@@ -25,6 +25,10 @@ class AdminRecruitmentAPITestCase(TestCase):
         )
         self.client.force_authenticate(user=self.admin_user)
 
+        # 테스트용 태그 및 공고 생성
+        self.tag_python = Tag.objects.create(name="Python")
+        self.tag_django = Tag.objects.create(name="Django")
+
         self.recruitment = Recruitment.objects.create(
             author=self.admin_user,
             title="테스트 공고",
@@ -33,64 +37,69 @@ class AdminRecruitmentAPITestCase(TestCase):
             expected_headcount=3,
             views_count=15,
         )
+        self.recruitment.tags.add(self.tag_python)
 
     # 목록 조회
     def test_admin_can_list_recruitments(self) -> None:
-        # 관리자가 전체 공고 목록을 조회할 수 있는지 확인
-        url = reverse("admin_recruitment_list")
+        """관리자 전체 공고 목록 조회"""
+        url = reverse("admin-recruitment-list")
         res = self.client.get(url)
-        self.assertEqual(res.status_code, status.HTTP_200_OK, "목록 조회 응답 코드가 올바르지 않음")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         data = res.json()
-        results = data["results"] if "results" in data else data
-        self.assertEqual(results[0]["title"], "테스트 공고")
 
-    def test_admin_can_filter_closed_recruitments(self) -> None:
-        # 마감된 공고만 반환되는지 확인
+        self.assertIn("results", data)
+        self.assertIn("count", data)
+        self.assertEqual(data["results"][0]["title"], "테스트 공고")
+
+    def test_admin_can_filter_by_tags(self) -> None:
+        """태그 필터링 기능"""
+        url = f"{reverse('admin-recruitment-list')}?tags=Python&tags=Django"
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        data = res.json()
+        self.assertIn("results", data)
+
+    def test_admin_can_filter_open_and_closed(self) -> None:
+        """is_closed 필터 테스트"""
+        # 마감 상태로 변경
         self.recruitment.is_closed = True
         self.recruitment.save()
-        url = f"{reverse('admin_recruitment_list')}?is_closed=true"
-        res = self.client.get(url)
-        self.assertEqual(res.status_code, status.HTTP_200_OK)
-        data = res.json()
-        results = data["results"] if "results" in data else data
-        for item in results:
-            self.assertTrue(item["is_closed"], "마감된 공고만 반환되지 않음")
 
-    def test_admin_can_filter_open_recruitments(self) -> None:
-        # 진행 중인 공고만 반환되는지 확인
-        url = f"{reverse('admin_recruitment_list')}?is_closed=false"
-        res = self.client.get(url)
-        self.assertEqual(res.status_code, status.HTTP_200_OK)
-        data = res.json()
-        results = data["results"] if "results" in data else data
-        for item in results:
-            self.assertFalse(item["is_closed"], "진행 중 공고만 반환되지 않음")
+        url_closed = f"{reverse('admin-recruitment-list')}?is_closed=true"
+        res_closed = self.client.get(url_closed)
+        self.assertEqual(res_closed.status_code, status.HTTP_200_OK)
+        for item in res_closed.json()["results"]:
+            self.assertTrue(item["is_closed"])
 
-    def test_admin_can_filter_by_tag_name(self) -> None:
-        # 태그명으로 필터링 시 정상 응답 확인
-        url = f"{reverse('admin_recruitment_list')}?tag=테스트"
-        res = self.client.get(url)
-        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        url_open = f"{reverse('admin-recruitment-list')}?is_closed=false"
+        res_open = self.client.get(url_open)
+        self.assertEqual(res_open.status_code, status.HTTP_200_OK)
+        for item in res_open.json()["results"]:
+            self.assertFalse(item["is_closed"])
 
     # 상세 조회
     def test_admin_can_retrieve_recruitment_detail(self) -> None:
-        # 관리자가 특정 공고 상세 정보를 조회할 수 있는지 확인
-        url = reverse("admin_recruitment_detail", args=[self.recruitment.id])
+        """관리자 상세 조회"""
+        url = reverse("admin-recruitment-detail", args=[self.recruitment.id])
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(res.json()["title"], "테스트 공고")
+        body = res.json()
+        self.assertEqual(body["title"], "테스트 공고")
+        self.assertIn("tags", body)
+        self.assertIn("attachments", body)
+        self.assertIn("applications", body)
 
     def test_retrieve_nonexistent_recruitment_returns_404(self) -> None:
-        # 존재하지 않는 공고 조회 시 404 응답 반환 확인
-        url = reverse("admin_recruitment_detail", args=[9999])
+        """존재하지 않는 공고 조회 시 404"""
+        url = reverse("admin-recruitment-detail", args=[9999])
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn("message", res.json())
+        self.assertIn("detail", res.json())
 
     # 삭제
     def test_admin_can_delete_recruitment(self) -> None:
-        # 관리자가 공고를 정상적으로 삭제할 수 있는지 확인
-        url = reverse("admin_recruitment_detail", args=[self.recruitment.id])
+        """관리자 공고 삭제"""
+        url = reverse("admin-recruitment-detail", args=[self.recruitment.id])
         res = self.client.delete(url)
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(
@@ -99,23 +108,23 @@ class AdminRecruitmentAPITestCase(TestCase):
         )
 
     def test_delete_nonexistent_recruitment_returns_404(self) -> None:
-        # 존재하지 않는 공고 삭제 시 404 응답 반환 확인
-        url = reverse("admin_recruitment_detail", args=[9999])
+        """존재하지 않는 공고 삭제 시 404"""
+        url = reverse("admin-recruitment-detail", args=[9999])
         res = self.client.delete(url)
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn("message", res.json())
+        self.assertIn("detail", res.json())
 
     # 권한
     def test_non_admin_cannot_access_admin_endpoints(self) -> None:
-        # 일반 유저가 관리자용 엔드포인트 접근 시 403 응답 확인
+        """비관리자 접근 시 403"""
         user = User.objects.create_user(
             email="user@test.com",
-            password="1234",
+            password="user1234",
             birthday=date(1995, 5, 5),
             nickname="일반유저",
             phone_number="01099998888",
         )
         self.client.force_authenticate(user=user)
-        url = reverse("admin_recruitment_list")
+        url = reverse("admin-recruitment-list")
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/recruitments/tests/test_admin_recruitments_api.py
+++ b/apps/recruitments/tests/test_admin_recruitments_api.py
@@ -40,7 +40,9 @@ class AdminRecruitmentAPITestCase(TestCase):
         url = reverse("admin_recruitment_list")
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_200_OK, "목록 조회 응답 코드가 올바르지 않음")
-        self.assertEqual(res.json()[0]["title"], "테스트 공고")
+        data = res.json()
+        results = data["results"] if "results" in data else data
+        self.assertEqual(results[0]["title"], "테스트 공고")
 
     def test_admin_can_filter_closed_recruitments(self) -> None:
         # 마감된 공고만 반환되는지 확인
@@ -49,7 +51,9 @@ class AdminRecruitmentAPITestCase(TestCase):
         url = f"{reverse('admin_recruitment_list')}?is_closed=true"
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        for item in res.json():
+        data = res.json()
+        results = data["results"] if "results" in data else data
+        for item in results:
             self.assertTrue(item["is_closed"], "마감된 공고만 반환되지 않음")
 
     def test_admin_can_filter_open_recruitments(self) -> None:
@@ -57,7 +61,9 @@ class AdminRecruitmentAPITestCase(TestCase):
         url = f"{reverse('admin_recruitment_list')}?is_closed=false"
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        for item in res.json():
+        data = res.json()
+        results = data["results"] if "results" in data else data
+        for item in results:
             self.assertFalse(item["is_closed"], "진행 중 공고만 반환되지 않음")
 
     def test_admin_can_filter_by_tag_name(self) -> None:
@@ -79,6 +85,7 @@ class AdminRecruitmentAPITestCase(TestCase):
         url = reverse("admin_recruitment_detail", args=[9999])
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("message", res.json())
 
     # 삭제
     def test_admin_can_delete_recruitment(self) -> None:
@@ -96,6 +103,7 @@ class AdminRecruitmentAPITestCase(TestCase):
         url = reverse("admin_recruitment_detail", args=[9999])
         res = self.client.delete(url)
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("message", res.json())
 
     # 권한
     def test_non_admin_cannot_access_admin_endpoints(self) -> None:

--- a/apps/recruitments/tests/test_admin_recruitments_api.py
+++ b/apps/recruitments/tests/test_admin_recruitments_api.py
@@ -32,29 +32,29 @@ class AdminRecruitmentAPITestCase(TestCase):
 
     def test_admin_list_recruitments(self) -> None:
         url = reverse("admin_recruitment_list")
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()[0]["title"], "테스트 공고")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.json()[0]["title"], "테스트 공고")
 
     def test_admin_filter_by_is_closed(self) -> None:
         self.recruitment.is_closed = True
         self.recruitment.save()
         url = f"{reverse('admin_recruitment_list')}?is_closed=true"
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        for item in response.json():
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        for item in res.json():
             self.assertTrue(item["is_closed"])
 
     def test_admin_retrieve_recruitment(self) -> None:
         url = reverse("admin_recruitment_detail", args=[self.recruitment.id])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["title"], "테스트 공고")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.json()["title"], "테스트 공고")
 
     def test_admin_delete_recruitment(self) -> None:
         url = reverse("admin_recruitment_detail", args=[self.recruitment.id])
-        response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        res = self.client.delete(url)
+        self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Recruitment.objects.filter(id=self.recruitment.id).exists())
 
     def test_non_admin_forbidden(self) -> None:
@@ -67,5 +67,25 @@ class AdminRecruitmentAPITestCase(TestCase):
         )
         self.client.force_authenticate(user=user)
         url = reverse("admin_recruitment_list")
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_filter_by_tag_name(self) -> None:
+        url = f"{reverse('admin_recruitment_list')}?tag=테스트"
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    def test_admin_filter_by_is_closed_false(self) -> None:
+        url = f"{reverse('admin_recruitment_list')}?is_closed=false"
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    def test_admin_retrieve_nonexistent_recruitment(self) -> None:
+        url = reverse("admin_recruitment_detail", args=[9999])
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_admin_delete_nonexistent_recruitment(self) -> None:
+        url = reverse("admin_recruitment_detail", args=[9999])
+        res = self.client.delete(url)
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)

--- a/apps/recruitments/tests/test_admin_recruitments_api.py
+++ b/apps/recruitments/tests/test_admin_recruitments_api.py
@@ -1,0 +1,71 @@
+from datetime import date
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.recruitments.models import Recruitment
+from apps.users.models import User
+
+
+class AdminRecruitmentAPITestCase(TestCase):
+    def setUp(self) -> None:
+        self.client: APIClient = APIClient()
+        self.admin_user = User.objects.create_superuser(
+            email="admin@test.com",
+            password="admin1234",
+            birthday=date(1990, 1, 1),
+            nickname="관리자",
+            phone_number="01012345678",
+        )
+        self.client.force_authenticate(user=self.admin_user)
+
+        self.recruitment = Recruitment.objects.create(
+            author=self.admin_user,
+            title="테스트 공고",
+            content="테스트용 공고 내용입니다.",
+            estimated_fee=10000,
+            expected_headcount=3,
+            views_count=15,
+        )
+
+    def test_admin_list_recruitments(self) -> None:
+        url = reverse("admin_recruitment_list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()[0]["title"], "테스트 공고")
+
+    def test_admin_filter_by_is_closed(self) -> None:
+        self.recruitment.is_closed = True
+        self.recruitment.save()
+        url = f"{reverse('admin_recruitment_list')}?is_closed=true"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for item in response.json():
+            self.assertTrue(item["is_closed"])
+
+    def test_admin_retrieve_recruitment(self) -> None:
+        url = reverse("admin_recruitment_detail", args=[self.recruitment.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["title"], "테스트 공고")
+
+    def test_admin_delete_recruitment(self) -> None:
+        url = reverse("admin_recruitment_detail", args=[self.recruitment.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Recruitment.objects.filter(id=self.recruitment.id).exists())
+
+    def test_non_admin_forbidden(self) -> None:
+        user = User.objects.create_user(
+            email="user@test.com",
+            password="1234",
+            birthday=date(1995, 5, 5),
+            nickname="일반유저",
+            phone_number="01099998888",
+        )
+        self.client.force_authenticate(user=user)
+        url = reverse("admin_recruitment_list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/recruitments/tests/test_tag.py
+++ b/apps/recruitments/tests/test_tag.py
@@ -106,6 +106,6 @@ class TestRecruitmentTagView(TestCase):
 
     def test_post_missing_recruitment_id(self) -> None:
         """recruitment_id 누락 시 404"""
-        invalid_url = "/api/v1/recruitments/tags"  # 잘못된 경로 (슬래시 제거)
+        invalid_url = "/api/v1/recruitments/tags"
         response: Any = self.client.post(invalid_url, {"name": "FastAPI"})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/apps/recruitments/urls/admin_urls.py
+++ b/apps/recruitments/urls/admin_urls.py
@@ -6,6 +6,6 @@ from apps.recruitments.views.admin_views import (
 )
 
 urlpatterns = [
-    path("", AdminRecruitmentListAPIView.as_view(), name="admin_recruitment_list"),
-    path("<int:recruitment_id>/", AdminRecruitmentDetailAPIView.as_view(), name="admin_recruitment_detail"),
+    path("", AdminRecruitmentListAPIView.as_view(), name="admin-recruitment-list"),
+    path("<int:recruitment_id>", AdminRecruitmentDetailAPIView.as_view(), name="admin-recruitment-detail"),
 ]

--- a/apps/recruitments/urls/admin_urls.py
+++ b/apps/recruitments/urls/admin_urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from apps.recruitments.views.admin_views import (
+    AdminRecruitmentDetailAPIView,
+    AdminRecruitmentListAPIView,
+)
+
+urlpatterns = [
+    path("", AdminRecruitmentListAPIView.as_view(), name="admin_recruitment_list"),
+    path("<int:recruitment_id>/", AdminRecruitmentDetailAPIView.as_view(), name="admin_recruitment_detail"),
+]

--- a/apps/recruitments/views/admin_views.py
+++ b/apps/recruitments/views/admin_views.py
@@ -17,38 +17,13 @@ from apps.recruitments.serializers.admin_serializers import (
 
 
 class AdminRecruitmentPagination(PageNumberPagination):
-    # 관리자 공고 목록 페이지네이션
+    """관리자 공고 목록 페이지네이션"""
     page_size = 10
     page_size_query_param = "page_size"
 
-    def get_paginated_response(self, data: list[Any]) -> Response:
-        total = Recruitment.objects.count()
-        open_count = Recruitment.objects.filter(is_closed=False).count()
-        closed_count = Recruitment.objects.filter(is_closed=True).count()
-
-        # 페이지네이션이 비활성화된 경우(테스트용)
-        if not hasattr(self, "page") or self.page is None or not hasattr(self.page, "paginator"):
-            return Response(
-                {
-                    "results": data,
-                    "count": {"total": total, "open": open_count, "closed": closed_count},
-                    "page": None,
-                    "page_size": None,
-                }
-            )
-
-        return Response(
-            {
-                "results": data,
-                "page": self.page.number,
-                "page_size": self.page.paginator.per_page,
-                "count": {"total": total, "open": open_count, "closed": closed_count},
-            }
-        )
-
 
 class AdminRecruitmentListAPIView(generics.ListAPIView[Recruitment]):
-    # 관리자 공고 목록 조회
+    """관리자 공고 목록 조회"""
     serializer_class = AdminRecruitmentListSerializer
     permission_classes = [IsAdminUser]
     pagination_class = AdminRecruitmentPagination
@@ -69,7 +44,7 @@ class AdminRecruitmentListAPIView(generics.ListAPIView[Recruitment]):
         if title:
             qs = qs.filter(title__icontains=title)
 
-        # 상태와 is_closed=true/false 둘 다 지원
+        # 상태(status=open/closed) 또는 is_closed=true/false 모두 지원
         if status_param in ("open", "closed"):
             qs = qs.filter(is_closed=(status_param == "closed"))
         elif is_closed_param in ("true", "false", "True", "False"):
@@ -83,7 +58,7 @@ class AdminRecruitmentListAPIView(generics.ListAPIView[Recruitment]):
 
 
 class AdminRecruitmentDetailAPIView(APIView):
-    # 관리자 공고 상세 조회 및 삭제
+    """관리자 공고 상세 조회 및 삭제"""
     permission_classes = [IsAdminUser]
     parser_classes = [parsers.JSONParser]
 
@@ -102,7 +77,6 @@ class AdminRecruitmentDetailAPIView(APIView):
     def get(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
         recruitment = self.get_object(recruitment_id)
         if not recruitment:
-            # 존재하지 않을 경우 404
             return Response({"detail": "조회하려는 공고가 존재하지 않습니다."}, status=status.HTTP_404_NOT_FOUND)
 
         serializer = AdminRecruitmentDetailSerializer(recruitment)
@@ -123,5 +97,4 @@ class AdminRecruitmentDetailAPIView(APIView):
             return Response({"detail": "삭제하려는 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
 
         recruitment.delete()
-        # 테스트 커버리지용 명시적 반환
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/recruitments/views/admin_views.py
+++ b/apps/recruitments/views/admin_views.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import parsers, status
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAdminUser
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -14,61 +15,87 @@ from apps.recruitments.serializers.admin_serializers import (
 )
 
 
-class AdminRecruitmentListAPIView(APIView):
-    """관리자용 스터디 구인 공고 목록 조회 (태그명, 마감 여부 필터 지원)"""
+# 관리자용 공고 목록 페이지네이션 설정
+class RecruitmentAdminPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 50
 
+
+class AdminRecruitmentListAPIView(APIView):
+    # 관리자용 스터디 구인공고 목록 조회
     permission_classes = [IsAdminUser]
     serializer_class = AdminRecruitmentSerializer
+    pagination_class = RecruitmentAdminPagination
 
     @extend_schema(
         tags=["AdminRecruitments"],
         summary="관리자용 스터디 구인공고 목록 조회",
+        description="관리자가 등록된 스터디 구인공고를 조회합니다. 태그(tag), 마감 여부(is_closed) 필터 및 페이지네이션(page, page_size)을 지원합니다.",
         parameters=[
-            OpenApiParameter(name="tag", type=str, description="태그명 필터"),
-            OpenApiParameter(name="is_closed", type=bool, description="마감 여부 필터"),
+            OpenApiParameter("tag", str, description="태그명 필터"),
+            OpenApiParameter("is_closed", bool, description="마감 여부 필터 (true / false)"),
+            OpenApiParameter("page", int, description="페이지 번호 (기본값 1)"),
+            OpenApiParameter("page_size", int, description="페이지당 항목 수 (기본값 10)"),
         ],
         responses={200: AdminRecruitmentSerializer(many=True)},
     )
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        queryset = Recruitment.objects.prefetch_related("tags", "author", "study_group")
+        # 기본 쿼리셋 (최신순 정렬 추가)
+        qs = (
+            Recruitment.objects.select_related("author", "study_group").prefetch_related("tags").order_by("-created_at")
+        )
 
         # 태그명 필터
-        tag_name = request.query_params.get("tag")
-        if tag_name:
-            queryset = queryset.filter(tags__name__icontains=tag_name)
+        tag = request.query_params.get("tag")
+        if tag:
+            qs = qs.filter(tags__name__icontains=tag)
 
         # 마감 여부 필터
-        is_closed_param = request.query_params.get("is_closed")
-        if is_closed_param is not None:
-            value = is_closed_param.strip().lower()
-            if value in ("true", "1"):
-                queryset = queryset.filter(is_closed=True)
-            elif value in ("false", "0"):
-                queryset = queryset.filter(is_closed=False)
+        is_closed = request.query_params.get("is_closed")
+        if is_closed:
+            v = is_closed.lower()
+            if v in ("true", "1"):
+                qs = qs.filter(is_closed=True)
+            elif v in ("false", "0"):
+                qs = qs.filter(is_closed=False)
 
-        serializer = self.serializer_class(queryset, many=True)
-        return Response(serializer.data)
+        # 페이지네이션 적용
+        paginator = self.pagination_class()
+        page = paginator.paginate_queryset(qs, request)
+        serializer = self.serializer_class(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
 
 
 class AdminRecruitmentDetailAPIView(APIView):
-    """관리자용 스터디 구인 공고 상세 조회 및 삭제"""
-
+    # 관리자용 스터디 구인공고 상세 조회 및 삭제
     permission_classes = [IsAdminUser]
     parser_classes = [parsers.JSONParser, parsers.MultiPartParser]
     serializer_class = AdminRecruitmentDetailSerializer
 
+    # 단일 공고 조회
     def get_object(self, recruitment_id: int) -> Recruitment | None:
-        return Recruitment.objects.prefetch_related("tags", "author", "study_group").filter(id=recruitment_id).first()
+        return (
+            Recruitment.objects.select_related("author", "study_group")
+            .prefetch_related("tags")
+            .filter(id=recruitment_id)
+            .first()
+        )
 
     @extend_schema(
         tags=["AdminRecruitments"],
         summary="관리자용 스터디 구인공고 상세 조회",
-        responses={200: AdminRecruitmentDetailSerializer},
+        description="특정 스터디 구인공고의 상세 정보를 조회합니다.",
+        responses={
+            200: AdminRecruitmentDetailSerializer,
+            404: {"type": "object", "properties": {"message": {"type": "string"}}},
+        },
     )
     def get(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
+        # 공고 상세 조회
         recruitment = self.get_object(recruitment_id)
         if not recruitment:
-            return Response({"detail": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
 
         serializer = self.serializer_class(recruitment)
         return Response(serializer.data)
@@ -76,12 +103,17 @@ class AdminRecruitmentDetailAPIView(APIView):
     @extend_schema(
         tags=["AdminRecruitments"],
         summary="관리자용 스터디 구인공고 삭제",
-        responses={204: None, 404: {"detail": "해당 공고를 찾을 수 없습니다."}},
+        description="특정 스터디 구인공고를 삭제합니다.",
+        responses={
+            204: None,
+            404: {"type": "object", "properties": {"message": {"type": "string"}}},
+        },
     )
     def delete(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
+        # 공고 삭제
         recruitment = self.get_object(recruitment_id)
         if not recruitment:
-            return Response({"detail": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
 
         recruitment.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/recruitments/views/admin_views.py
+++ b/apps/recruitments/views/admin_views.py
@@ -1,7 +1,8 @@
-from typing import Any
+from typing import Any, Optional
 
-from drf_spectacular.utils import OpenApiParameter, extend_schema
-from rest_framework import parsers, status
+from django.db.models import QuerySet
+from drf_spectacular.utils import extend_schema
+from rest_framework import generics, parsers, status
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAdminUser
 from rest_framework.request import Request
@@ -11,73 +12,84 @@ from rest_framework.views import APIView
 from apps.recruitments.models import Recruitment
 from apps.recruitments.serializers.admin_serializers import (
     AdminRecruitmentDetailSerializer,
-    AdminRecruitmentSerializer,
+    AdminRecruitmentListSerializer,
 )
 
 
-# 관리자용 공고 목록 페이지네이션 설정
-class RecruitmentAdminPagination(PageNumberPagination):
+class AdminRecruitmentPagination(PageNumberPagination):
+    # 관리자 공고 목록 페이지네이션
     page_size = 10
     page_size_query_param = "page_size"
-    max_page_size = 50
+
+    def get_paginated_response(self, data: list[Any]) -> Response:
+        total = Recruitment.objects.count()
+        open_count = Recruitment.objects.filter(is_closed=False).count()
+        closed_count = Recruitment.objects.filter(is_closed=True).count()
+
+        # 페이지네이션이 비활성화된 경우(테스트용)
+        if not hasattr(self, "page") or self.page is None or not hasattr(self.page, "paginator"):
+            return Response(
+                {
+                    "results": data,
+                    "count": {"total": total, "open": open_count, "closed": closed_count},
+                    "page": None,
+                    "page_size": None,
+                }
+            )
+
+        return Response(
+            {
+                "results": data,
+                "page": self.page.number,
+                "page_size": self.page.paginator.per_page,
+                "count": {"total": total, "open": open_count, "closed": closed_count},
+            }
+        )
 
 
-class AdminRecruitmentListAPIView(APIView):
-    # 관리자용 스터디 구인공고 목록 조회
+class AdminRecruitmentListAPIView(generics.ListAPIView[Recruitment]):
+    # 관리자 공고 목록 조회
+    serializer_class = AdminRecruitmentListSerializer
     permission_classes = [IsAdminUser]
-    serializer_class = AdminRecruitmentSerializer
-    pagination_class = RecruitmentAdminPagination
+    pagination_class = AdminRecruitmentPagination
 
     @extend_schema(
         tags=["AdminRecruitments"],
         summary="관리자용 스터디 구인공고 목록 조회",
-        description="관리자가 등록된 스터디 구인공고를 조회합니다. 태그(tag), 마감 여부(is_closed) 필터 및 페이지네이션(page, page_size)을 지원합니다.",
-        parameters=[
-            OpenApiParameter("tag", str, description="태그명 필터"),
-            OpenApiParameter("is_closed", bool, description="마감 여부 필터 (true / false)"),
-            OpenApiParameter("page", int, description="페이지 번호 (기본값 1)"),
-            OpenApiParameter("page_size", int, description="페이지당 항목 수 (기본값 10)"),
-        ],
-        responses={200: AdminRecruitmentSerializer(many=True)},
+        responses={200: AdminRecruitmentListSerializer(many=True)},
     )
-    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        # 기본 쿼리셋 (최신순 정렬 추가)
-        qs = (
-            Recruitment.objects.select_related("author", "study_group").prefetch_related("tags").order_by("-created_at")
-        )
+    def get_queryset(self) -> QuerySet[Recruitment]:
+        qs = Recruitment.objects.all().prefetch_related("tags")
 
-        # 태그명 필터
-        tag = request.query_params.get("tag")
-        if tag:
-            qs = qs.filter(tags__name__icontains=tag)
+        title = self.request.query_params.get("title")
+        status_param = self.request.query_params.get("status")
+        is_closed_param = self.request.query_params.get("is_closed")
+        tag_names = self.request.query_params.getlist("tags")
 
-        # 마감 여부 필터
-        is_closed = request.query_params.get("is_closed")
-        if is_closed:
-            v = is_closed.lower()
-            if v in ("true", "1"):
-                qs = qs.filter(is_closed=True)
-            elif v in ("false", "0"):
-                qs = qs.filter(is_closed=False)
+        if title:
+            qs = qs.filter(title__icontains=title)
 
-        # 페이지네이션 적용
-        paginator = self.pagination_class()
-        page = paginator.paginate_queryset(qs, request)
-        serializer = self.serializer_class(page, many=True)
-        return paginator.get_paginated_response(serializer.data)
+        # 상태와 is_closed=true/false 둘 다 지원
+        if status_param in ("open", "closed"):
+            qs = qs.filter(is_closed=(status_param == "closed"))
+        elif is_closed_param in ("true", "false", "True", "False"):
+            qs = qs.filter(is_closed=(is_closed_param.lower() == "true"))
+
+        if tag_names:
+            qs = qs.filter(tags__name__in=tag_names).distinct()
+
+        ordering = self.request.query_params.get("ordering", "-created_at")
+        return qs.order_by(ordering)
 
 
 class AdminRecruitmentDetailAPIView(APIView):
-    # 관리자용 스터디 구인공고 상세 조회 및 삭제
+    # 관리자 공고 상세 조회 및 삭제
     permission_classes = [IsAdminUser]
-    parser_classes = [parsers.JSONParser, parsers.MultiPartParser]
-    serializer_class = AdminRecruitmentDetailSerializer
+    parser_classes = [parsers.JSONParser]
 
-    # 단일 공고 조회
-    def get_object(self, recruitment_id: int) -> Recruitment | None:
+    def get_object(self, recruitment_id: int) -> Optional[Recruitment]:
         return (
-            Recruitment.objects.select_related("author", "study_group")
-            .prefetch_related("tags")
+            Recruitment.objects.prefetch_related("tags", "attachments", "applications")
             .filter(id=recruitment_id)
             .first()
         )
@@ -85,35 +97,31 @@ class AdminRecruitmentDetailAPIView(APIView):
     @extend_schema(
         tags=["AdminRecruitments"],
         summary="관리자용 스터디 구인공고 상세 조회",
-        description="특정 스터디 구인공고의 상세 정보를 조회합니다.",
-        responses={
-            200: AdminRecruitmentDetailSerializer,
-            404: {"type": "object", "properties": {"message": {"type": "string"}}},
-        },
+        responses={200: AdminRecruitmentDetailSerializer},
     )
     def get(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
-        # 공고 상세 조회
         recruitment = self.get_object(recruitment_id)
         if not recruitment:
-            return Response({"message": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+            # 존재하지 않을 경우 404
+            return Response({"detail": "조회하려는 공고가 존재하지 않습니다."}, status=status.HTTP_404_NOT_FOUND)
 
-        serializer = self.serializer_class(recruitment)
-        return Response(serializer.data)
+        serializer = AdminRecruitmentDetailSerializer(recruitment)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     @extend_schema(
         tags=["AdminRecruitments"],
         summary="관리자용 스터디 구인공고 삭제",
-        description="특정 스터디 구인공고를 삭제합니다.",
         responses={
             204: None,
-            404: {"type": "object", "properties": {"message": {"type": "string"}}},
+            400: {"type": "object", "properties": {"detail": {"type": "string"}}},
+            404: {"type": "object", "properties": {"detail": {"type": "string"}}},
         },
     )
     def delete(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
-        # 공고 삭제
         recruitment = self.get_object(recruitment_id)
         if not recruitment:
-            return Response({"message": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"detail": "삭제하려는 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
 
         recruitment.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        # 테스트 커버리지용 명시적 반환
+        return Response({"detail": "삭제 완료"}, status=status.HTTP_204_NO_CONTENT)

--- a/apps/recruitments/views/admin_views.py
+++ b/apps/recruitments/views/admin_views.py
@@ -124,4 +124,4 @@ class AdminRecruitmentDetailAPIView(APIView):
 
         recruitment.delete()
         # 테스트 커버리지용 명시적 반환
-        return Response({"detail": "삭제 완료"}, status=status.HTTP_204_NO_CONTENT)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/recruitments/views/admin_views.py
+++ b/apps/recruitments/views/admin_views.py
@@ -1,0 +1,87 @@
+from typing import Any
+
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import parsers, status
+from rest_framework.permissions import IsAdminUser
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.recruitments.models import Recruitment
+from apps.recruitments.serializers.admin_serializers import (
+    AdminRecruitmentDetailSerializer,
+    AdminRecruitmentSerializer,
+)
+
+
+class AdminRecruitmentListAPIView(APIView):
+    """관리자용 스터디 구인 공고 목록 조회 (태그명, 마감 여부 필터 지원)"""
+
+    permission_classes = [IsAdminUser]
+    serializer_class = AdminRecruitmentSerializer
+
+    @extend_schema(
+        tags=["AdminRecruitments"],
+        summary="관리자용 스터디 구인공고 목록 조회",
+        parameters=[
+            OpenApiParameter(name="tag", type=str, description="태그명 필터"),
+            OpenApiParameter(name="is_closed", type=bool, description="마감 여부 필터"),
+        ],
+        responses={200: AdminRecruitmentSerializer(many=True)},
+    )
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        queryset = Recruitment.objects.prefetch_related("tags", "author", "study_group")
+
+        # 태그명 필터
+        tag_name = request.query_params.get("tag")
+        if tag_name:
+            queryset = queryset.filter(tags__name__icontains=tag_name)
+
+        # 마감 여부 필터
+        is_closed_param = request.query_params.get("is_closed")
+        if is_closed_param is not None:
+            value = is_closed_param.strip().lower()
+            if value in ("true", "1"):
+                queryset = queryset.filter(is_closed=True)
+            elif value in ("false", "0"):
+                queryset = queryset.filter(is_closed=False)
+
+        serializer = self.serializer_class(queryset, many=True)
+        return Response(serializer.data)
+
+
+class AdminRecruitmentDetailAPIView(APIView):
+    """관리자용 스터디 구인 공고 상세 조회 및 삭제"""
+
+    permission_classes = [IsAdminUser]
+    parser_classes = [parsers.JSONParser, parsers.MultiPartParser]
+    serializer_class = AdminRecruitmentDetailSerializer
+
+    def get_object(self, recruitment_id: int) -> Recruitment | None:
+        return Recruitment.objects.prefetch_related("tags", "author", "study_group").filter(id=recruitment_id).first()
+
+    @extend_schema(
+        tags=["AdminRecruitments"],
+        summary="관리자용 스터디 구인공고 상세 조회",
+        responses={200: AdminRecruitmentDetailSerializer},
+    )
+    def get(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
+        recruitment = self.get_object(recruitment_id)
+        if not recruitment:
+            return Response({"detail": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = self.serializer_class(recruitment)
+        return Response(serializer.data)
+
+    @extend_schema(
+        tags=["AdminRecruitments"],
+        summary="관리자용 스터디 구인공고 삭제",
+        responses={204: None, 404: {"detail": "해당 공고를 찾을 수 없습니다."}},
+    )
+    def delete(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
+        recruitment = self.get_object(recruitment_id)
+        if not recruitment:
+            return Response({"detail": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+
+        recruitment.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/recruitments/views/admin_views.py
+++ b/apps/recruitments/views/admin_views.py
@@ -18,12 +18,14 @@ from apps.recruitments.serializers.admin_serializers import (
 
 class AdminRecruitmentPagination(PageNumberPagination):
     """관리자 공고 목록 페이지네이션"""
+
     page_size = 10
     page_size_query_param = "page_size"
 
 
 class AdminRecruitmentListAPIView(generics.ListAPIView[Recruitment]):
     """관리자 공고 목록 조회"""
+
     serializer_class = AdminRecruitmentListSerializer
     permission_classes = [IsAdminUser]
     pagination_class = AdminRecruitmentPagination
@@ -59,6 +61,7 @@ class AdminRecruitmentListAPIView(generics.ListAPIView[Recruitment]):
 
 class AdminRecruitmentDetailAPIView(APIView):
     """관리자 공고 상세 조회 및 삭제"""
+
     permission_classes = [IsAdminUser]
     parser_classes = [parsers.JSONParser]
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,9 +13,10 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/", include("apps.users.urls")),
     path("api/v1/", include("apps.recruitments.urls.tag")),
     path("api/v1/studies/", include("apps.studies.urls")),
-    path("api/v1/recruitments/", include("apps.recruitments.urls")),
     path("api/v1/notifications/", include("apps.notifications.urls")),
     path("api/v1/chat/", include("apps.chat.urls")),
+    path("api/v1/recruitments", include("apps.recruitments.urls")),
+    path("api/v1/admin/recruitments", include("apps.recruitments.urls.admin_urls")),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 관리자용 스터디 구인공고 관리 API (목록 조회, 상세 조회, 삭제) 구현

## 📄 상세 내용
-관리자용 목록 조회 API (GET /api/v1/admin/recruitments) 구현
태그명(tag=) 및 마감 여부(is_closed=) 필터링 기능 추가
IsAdminUser 권한 클래스 적용
직렬화기: AdminRecruitmentSerializer
prefetch_related("tags", "author", "study_group")로 성능 최적화

-관리자용 상세 조회 API (GET /api/v1/admin/recruitments/{recruitment_id}/) 구현
상세 정보 응답에 tags, author_nickname, study_group_name 포함
존재하지 않는 공고 접근 시 404 반환
직렬화기: AdminRecruitmentDetailSerializer

-관리자용 삭제 API (DELETE /api/v1/admin/recruitments/{recruitment_id}/) 구현
존재하지 않는 공고 삭제 시 404 반환, 정상 삭제 시 204 No Content
현재 실제 삭제(.delete()) 방식 적용

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
다음주월에 팀원이랑공유후문제있으면 같이수정할예정 

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
