### PR TITLE
🐛 Fix: 채팅방 자동 퇴장 및 읽음 처리 기능 추가 보완

### DIFF
--- a/apps/chat/consumers.py
+++ b/apps/chat/consumers.py
@@ -10,7 +10,7 @@ from channels.generic.websocket import (
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser
 
-from apps.chat.models import ChatMessage
+from apps.chat.models import ChatMessage, LastReadMessage
 from apps.studies.models.groups import GroupMember, StudyGroup
 from apps.users.models.user import User
 
@@ -18,23 +18,52 @@ from apps.users.models.user import User
 class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
     study_group_id: int
     room_group_name: str
+    user: AbstractBaseUser
 
     async def connect(self) -> None:
         self.study_group_id = self.scope["url_route"]["kwargs"]["study_group_id"]
         self.room_group_name = f"chat_{self.study_group_id}"
-        user = self.scope["user"]
+        self.user = self.scope["user"]
 
-        if not await self.is_valid_study_group() or not await self.is_group_member(user):
+        if not await self.is_valid_study_group() or not await self.is_group_member(self.user):
             await self.close(code=403)
             return
 
         # Join room group
         await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+
+        # Join user-specific group to allow direct messaging
+        if self.user.is_authenticated:
+            assert isinstance(self.user, User)
+            await self.channel_layer.group_add(f"user_{self.user.id}", self.channel_name)
+
         await self.accept()
+
+        # Mark all messages as read upon connection
+        if self.user.is_authenticated:
+            assert isinstance(self.user, User)
+            await self.mark_messages_as_read()
+
+    async def mark_messages_as_read(self) -> None:
+        """
+        Marks all messages in the current study group as read for the current user.
+        """
+        latest_message = await ChatMessage.objects.filter(study_group_id=self.study_group_id).alast()
+        if latest_message:
+            await LastReadMessage.objects.aupdate_or_create(
+                study_group_id=self.study_group_id,
+                user=self.user,
+                defaults={"message": latest_message},
+            )
 
     async def disconnect(self, close_code: int) -> None:
         # Leave room group
         await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+
+        # Leave user-specific group
+        if self.user.is_authenticated:
+            assert isinstance(self.user, User)
+            await self.channel_layer.group_discard(f"user_{self.user.id}", self.channel_name)
 
     # Receive message from WebSocket
     async def receive_json(self, content: dict[str, Any], **kwargs: Any) -> None:
@@ -44,8 +73,11 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
         if message_type == "chat.message":
             message_content = content.get("content", "").strip()  # Ensure message_content is always a string
 
+            sender_id = None
             if user.is_authenticated:
+                assert isinstance(user, User)
                 await self.create_chat_message(user, message_content)
+                sender_id = user.id
 
             # Send message to room group
             await self.channel_layer.group_send(
@@ -53,7 +85,7 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
                 {
                     "type": "chat_message",
                     "message": message_content,
-                    "sender_id": user.id if user.is_authenticated else None,
+                    "sender_id": sender_id,
                 },
             )
 
@@ -88,3 +120,24 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
                 ensure_ascii=False,
             )
         )
+
+    async def system_message(self, event: dict[str, Any]) -> None:
+        """Handler for system messages."""
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": "chat.system",
+                    "message": event["message"],
+                },
+                ensure_ascii=False,
+            )
+        )
+
+    async def force_disconnect(self, event: dict[str, Any]) -> None:
+        """
+        Handler for the 'force_disconnect' event.
+        Closes the WebSocket connection.
+        """
+        disconnected_study_group_id = event.get("study_group_id")
+        if disconnected_study_group_id == self.study_group_id:
+            await self.close(code=4001)

--- a/apps/chat/services/chat_service.py
+++ b/apps/chat/services/chat_service.py
@@ -1,5 +1,7 @@
 from uuid import UUID
 
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from django.db import transaction
 from django.db.models import Count, IntegerField, OuterRef, QuerySet, Subquery, Value
 from django.db.models.functions import Coalesce
@@ -73,3 +75,36 @@ class ChatRoomService:
         )
         # TODO: 메시지 생성 후 관련 로직 추가 (예: 웹소켓으로 브로드캐스트)
         return chat_message
+
+    @staticmethod
+    def broadcast_member_removal(study_group_id: int, user_id: int, user_nickname: str, is_kick: bool) -> None:
+        """
+        스터디 멤버가 제거되었음을 실시간으로 브로드캐스트합니다.
+        - 제거된 사용자에게는 강제 접속 종료 메시지를 보냅니다.
+        - 다른 멤버들에게는 시스템 메시지를 보냅니다.
+        """
+        channel_layer = get_channel_layer()
+        room_group_name = f"chat_{study_group_id}"
+
+        # 1. 제거된 사용자에게 강제 접속 종료 메시지 전송
+        async_to_sync(channel_layer.group_send)(
+            f"user_{user_id}",
+            {
+                "type": "force_disconnect",
+                "study_group_id": study_group_id,
+            },
+        )
+
+        # 2. 채팅방의 다른 멤버들에게 시스템 메시지 전송
+        if is_kick:
+            message = f"{user_nickname}님이 리더에 의해 스터디에서 제외되었습니다."
+        else:
+            message = f"{user_nickname}님이 스터디를 떠났습니다."
+
+        async_to_sync(channel_layer.group_send)(
+            room_group_name,
+            {
+                "type": "system_message",
+                "message": message,
+            },
+        )

--- a/apps/chat/tests/test_chat_consumers.py
+++ b/apps/chat/tests/test_chat_consumers.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import TransactionTestCase
 
 from apps.chat.consumers import ChatConsumer
-from apps.chat.models.chat_message import ChatMessage
+from apps.chat.models import ChatMessage, LastReadMessage
 from apps.studies.models.groups import GroupMember, StudyGroup
 from apps.users.models.user import User
 
@@ -26,6 +26,11 @@ class ChatConsumerTest(TransactionTestCase):
     def _create_group_member(self, **kwargs: Any) -> GroupMember:
         """동기 방식으로 그룹 멤버 생성"""
         return GroupMember.objects.create(**kwargs)
+
+    @sync_to_async
+    def _create_chat_message(self, **kwargs: Any) -> ChatMessage:
+        """동기 방식으로 채팅 메시지 생성"""
+        return ChatMessage.objects.create(**kwargs)
 
     """
     Test suite for the ChatConsumer.
@@ -201,7 +206,7 @@ class ChatConsumerTest(TransactionTestCase):
             gender="M",
             birthday="2000-01-01",
         )
-        study_group = await StudyGroup.objects.acreate(
+        study_group = await self._create_study_group(
             name="Test Study Group",
             max_headcount=10,
             start_at="2025-10-21T10:00:00Z",
@@ -218,3 +223,44 @@ class ChatConsumerTest(TransactionTestCase):
         self.assertEqual(subprotocol, 403)
 
         await communicator.disconnect()
+
+    async def test_mark_messages_as_read_logic(self) -> None:
+        """
+        Tests that the mark_messages_as_read method correctly updates the LastReadMessage.
+        This test calls the method directly to bypass transaction issues with the test server.
+        """
+        # 1. Create test data
+        user = await self._create_user(
+            email="testuser@example.com",
+            password="password123",
+            nickname="testuser",
+            phone_number="01012345678",
+            name="Test User",
+            gender="M",
+            birthday="2000-01-01",
+        )
+        study_group = await self._create_study_group(
+            name="Test Study Group",
+            max_headcount=10,
+            start_at="2025-10-21T10:00:00Z",
+            end_at="2025-11-21T10:00:00Z",
+        )
+        await self._create_group_member(study_group=study_group, user=user)
+
+        # 2. Create some messages
+        await self._create_chat_message(study_group=study_group, sender=user, content="Message 1")
+        last_message = await self._create_chat_message(study_group=study_group, sender=user, content="Message 2")
+
+        # 3. Directly instantiate the consumer and call the method
+        consumer = ChatConsumer()
+        consumer.scope = {"user": user}
+        consumer.study_group_id = study_group.id
+        consumer.user = user
+
+        await consumer.mark_messages_as_read()
+
+        # 4. Verify LastReadMessage is updated
+        last_read_entry = await LastReadMessage.objects.select_related("message").aget(
+            user=user, study_group=study_group
+        )
+        self.assertEqual(last_read_entry.message, last_message)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 멤버 퇴장/추방 알림: 스터디 그룹에서 멤버가 나가거나 추방되었을 때, 이를 채팅방에 실시간으로 반영
- 자동 읽음 처리: 사용자가 채팅방에 입장하면 해당 방의 모든 메시지를 자동으로 읽음 처리

## 📄 상세 내용
- [x] 채팅방 멤버 퇴장/추방 시 실시간 알림 기능 추가 보완
- studies와 같은 다른 앱에서 호출하여 사용할 수 있도록 chat 앱에 서비스 함수를 구현
- apps/chat/services/chat_service.py :
   ChatRoomService에 broadcast_member_removal 메서드를 추가
- 동작:
   강제 접속 종료: 퇴장/추방된 사용자에게는 웹소켓 연결을 끊으라는 force_disconnect 이벤트를 전송
   시스템 메시지 전송: 채팅방에 남아있는 다른 멤버들에게는 "OO님이 스터디를 떠났습니다."와 같은 system_message를 전송
- apps/chat/consumers.py :
   위 두 이벤트(force_disconnect, system_message)를 수신하여 실제 동작을 수행하는 핸들러를 구현

- [x] 채팅방 입장 시 자동 읽음 처리 기능 추가 (프론트엔드 요청사항)
- 사용자가 채팅방에 들어왔을 때, 안 읽은 메시지 수를 갱신하기 위한 로직을 구현
- apps/chat/consumers.py :
   사용자가 웹소켓에 연결(connect)하면, mark_messages_as_read 라는 새로운 메서드가 호출됩니다.
   동작:
   해당 채팅방의 가장 최신 메시지를 조회 -> LastReadMessage 테이블에서 "현재 사용자가 이 채팅방의 몇 번 메시지까지 읽었는지"에 대한 정보를 최신 메시지로 업데이트
   이를 통해 채팅방에 입장하는 즉시 모든 메시지가 읽음 처리

- [x] Mypy 타입 오류 수정: ChatConsumer에서 인증된 사용자의 id 속성을 참조할 때 발생하던 타입 불일치 문제를 assert isinstance(user, User) 구문을 추가하여 명시적으로 타입을 검증함으로써 해결

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- [x] 프론트엔드 요청사항:
       확인/보완 필요 : '현재 접속 중인 인원'을 표시하는 기능 미구현 -> 체크 후 진행 예정 (1순위)
       
- [x] 신규 요청 내용 : 전체 안 읽은 메시지 수 총합 API
       요청 내용 : 모든 채팅방의 '안 읽은 메시지 수'를 합산하여 총합을 단일 API로 제공해주길 원함
       현재 상태 : 미구현 -> 구현 예정 (2순위)

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
