### PR TITLE
✨ feat: notifications 개별/전체 알림 읽음 처리 API

### DIFF
--- a/apps/notifications/tests/test_read_views.py
+++ b/apps/notifications/tests/test_read_views.py
@@ -1,0 +1,75 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+from django.contrib.auth import get_user_model
+from rest_framework.response import Response
+from apps.notifications.models import Notification
+
+User = get_user_model()
+
+
+class NotificationReadAPITestCase(APITestCase):
+    def setUp(self) -> None:
+        """테스트용 사용자와 알림 데이터 생성"""
+        self.user = User.objects.create_user(
+            email="test@example.com",
+            password="testpass123",
+            nickname="testuser",
+            name="테스트유저",
+            phone_number="01012345678",
+            birthday="2000-12-31",
+            gender="MALE",
+        )
+
+        # 로그인 처리
+        self.client.force_authenticate(user=self.user)
+
+        # 테스트용 알림 데이터 생성
+        self.notification_unread = Notification.objects.create(
+            user=self.user,
+            content="읽지 않은 알림",
+            is_read=False,
+        )
+        self.notification_read = Notification.objects.create(
+            user=self.user,
+            content="이미 읽은 알림",
+            is_read=True,
+        )
+
+    def test_mark_notification_as_read_success(self) -> None:
+        """읽지 않은 알림을 읽음 처리하면 is_read=True로 변경되어야 한다"""
+        url = reverse("notification-read", args=[self.notification_unread.id])
+        response: Response = self.client.patch(url)
+        self.notification_unread.refresh_from_db()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(self.notification_unread.is_read)
+        self.assertEqual(response.data["detail"], "Notification marked as read")
+
+    def test_mark_notification_already_read(self) -> None:
+        """이미 읽은 알림에 다시 PATCH 요청하면 200 OK지만 상태는 그대로"""
+        url = reverse("notification-read", args=[self.notification_read.id])
+        response: Response = self.client.patch(url)
+        self.notification_read.refresh_from_db()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(self.notification_read.is_read)
+        self.assertEqual(response.data["detail"], "Notification already read")
+
+    def test_mark_notification_not_found(self) -> None:
+        """존재하지 않는 알림 ID로 요청하면 404 반환"""
+        url = reverse("notification-read", args=[9999])
+        response: Response = self.client.patch(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"], "Notification not found")
+
+    def test_mark_all_notifications_as_read(self) -> None:
+        """읽지 않은 모든 알림을 한 번에 읽음 처리"""
+        url = reverse("notification-read-all")
+        response: Response = self.client.patch(url)
+
+        unread_count = Notification.objects.filter(user=self.user, is_read=False).count()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("notifications marked as read", response.data["detail"])
+        self.assertEqual(unread_count, 0)

--- a/apps/notifications/tests/test_read_views.py
+++ b/apps/notifications/tests/test_read_views.py
@@ -1,8 +1,9 @@
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase, APIClient
-from django.contrib.auth import get_user_model
 from rest_framework.response import Response
+from rest_framework.test import APIClient, APITestCase
+
 from apps.notifications.models import Notification
 
 User = get_user_model()
@@ -38,7 +39,7 @@ class NotificationReadAPITestCase(APITestCase):
 
     def test_mark_notification_as_read_success(self) -> None:
         """읽지 않은 알림을 읽음 처리하면 is_read=True로 변경되어야 한다"""
-        url = reverse("notification-read", args=[self.notification_unread.id])
+        url = reverse("notifications:notification-read", args=[self.notification_unread.id])
         response: Response = self.client.patch(url)
         self.notification_unread.refresh_from_db()
 
@@ -48,7 +49,7 @@ class NotificationReadAPITestCase(APITestCase):
 
     def test_mark_notification_already_read(self) -> None:
         """이미 읽은 알림에 다시 PATCH 요청하면 200 OK지만 상태는 그대로"""
-        url = reverse("notification-read", args=[self.notification_read.id])
+        url = reverse("notifications:notification-read", args=[self.notification_read.id])
         response: Response = self.client.patch(url)
         self.notification_read.refresh_from_db()
 
@@ -58,7 +59,7 @@ class NotificationReadAPITestCase(APITestCase):
 
     def test_mark_notification_not_found(self) -> None:
         """존재하지 않는 알림 ID로 요청하면 404 반환"""
-        url = reverse("notification-read", args=[9999])
+        url = reverse("notifications:notification-read", args=[9999])
         response: Response = self.client.patch(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -66,7 +67,7 @@ class NotificationReadAPITestCase(APITestCase):
 
     def test_mark_all_notifications_as_read(self) -> None:
         """읽지 않은 모든 알림을 한 번에 읽음 처리"""
-        url = reverse("notification-read-all")
+        url = reverse("notifications:notification-read-all")
         response: Response = self.client.patch(url)
 
         unread_count = Notification.objects.filter(user=self.user, is_read=False).count()

--- a/apps/notifications/urls/__init__.py
+++ b/apps/notifications/urls/__init__.py
@@ -1,13 +1,11 @@
 from django.urls import URLPattern, URLResolver
 
-from apps.notifications.urls.list_urls import urlpatterns as list_urlpatterns
+from apps.notifications.urls.api_urls import urlpatterns as api_urlpatterns
 from apps.notifications.urls.sse_urls import urlpatterns as sse_urlpatterns
-from apps.notifications.urls.read_urls import urlpatterns as read_urlpatterns
 
 app_name = "notifications"
 
 urlpatterns: list[URLPattern | URLResolver] = [
-    *list_urlpatterns,
     *sse_urlpatterns,
-    *read_urlpatterns,
+    *api_urlpatterns,
 ]

--- a/apps/notifications/urls/__init__.py
+++ b/apps/notifications/urls/__init__.py
@@ -2,10 +2,12 @@ from django.urls import URLPattern, URLResolver
 
 from apps.notifications.urls.list_urls import urlpatterns as list_urlpatterns
 from apps.notifications.urls.sse_urls import urlpatterns as sse_urlpatterns
+from apps.notifications.urls.read_urls import urlpatterns as read_urlpatterns
 
 app_name = "notifications"
 
 urlpatterns: list[URLPattern | URLResolver] = [
     *list_urlpatterns,
     *sse_urlpatterns,
+    *read_urlpatterns,
 ]

--- a/apps/notifications/urls/api_urls.py
+++ b/apps/notifications/urls/api_urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from apps.notifications.views.read_views import (
+    mark_all_notification_as_read,
+    mark_notification_as_read,
+)
+from apps.notifications.views.views import NotificationListAPIView
+
+urlpatterns = [
+    path("notifications/<int:notification_id>/read/", mark_notification_as_read, name="notification-read"),
+    path("notifications/read-all/", mark_all_notification_as_read, name="notification-read-all"),
+    path("", NotificationListAPIView.as_view(), name="notification-list"),
+]

--- a/apps/notifications/urls/list_urls.py
+++ b/apps/notifications/urls/list_urls.py
@@ -1,7 +1,0 @@
-from django.urls import path
-
-from apps.notifications.views.views import NotificationListAPIView
-
-urlpatterns = [
-    path("", NotificationListAPIView.as_view(), name="notification-list"),
-]

--- a/apps/notifications/urls/read_urls.py
+++ b/apps/notifications/urls/read_urls.py
@@ -1,7 +1,0 @@
-from django.urls import path
-from apps.notifications.views.read_views import (mark_notification_as_read, mark_all_notification_as_read)
-
-urlpatterns = [
-    path("notifications/<int:notification_id>/read/", mark_notification_as_read, name="notification-read"),
-    path("notifications/read-all/", mark_all_notification_as_read, name="notification-read-all"),
-]

--- a/apps/notifications/urls/read_urls.py
+++ b/apps/notifications/urls/read_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from apps.notifications.views.read_views import (mark_notification_as_read, mark_all_notification_as_read)
+
+urlpatterns = [
+    path("notifications/<int:notification_id>/read/", mark_notification_as_read, name="notification-read"),
+    path("notifications/read-all/", mark_all_notification_as_read, name="notification-read-all"),
+]

--- a/apps/notifications/views/read_views.py
+++ b/apps/notifications/views/read_views.py
@@ -1,18 +1,19 @@
+from django.contrib.auth.models import AnonymousUser
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 from rest_framework.request import Request
-from django.contrib.auth.models import AnonymousUser
+from rest_framework.response import Response
 
 from apps.notifications.models import Notification
 
-#개별 알림 읽음 처리
+
+# 개별 알림 읽음 처리
 @api_view(["PATCH"])
 @permission_classes([IsAuthenticated])
 def mark_notification_as_read(request: Request, notification_id: int) -> Response:
     user = request.user
-    assert not isinstance(user, AnonymousUser) # mypy AnonymousUser 오류로 인해 타입 단언 추가
+    assert not isinstance(user, AnonymousUser)  # mypy AnonymousUser 오류로 인해 타입 단언 추가
 
     try:
         notification = Notification.objects.get(id=notification_id, user=user)
@@ -28,12 +29,13 @@ def mark_notification_as_read(request: Request, notification_id: int) -> Respons
 
     return Response({"detail": "Notification marked as read"}, status=status.HTTP_200_OK)
 
-#전체 알림 읽음 처리
+
+# 전체 알림 읽음 처리
 @api_view(["PATCH"])
 @permission_classes([IsAuthenticated])
 def mark_all_notification_as_read(request: Request) -> Response:
     user = request.user
-    assert not isinstance(user, AnonymousUser) # mypy AnonymousUser 오류로 인해 타입 단언 추가
+    assert not isinstance(user, AnonymousUser)  # mypy AnonymousUser 오류로 인해 타입 단언 추가
 
     # 해당 사용자의 읽지 않은(is_read=False) 알림을 모두 읽음(True)으로 변경
     updated_count = Notification.objects.filter(user=user, is_read=False).update(is_read=True)

--- a/apps/notifications/views/read_views.py
+++ b/apps/notifications/views/read_views.py
@@ -1,0 +1,40 @@
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.request import Request
+from django.contrib.auth.models import AnonymousUser
+
+from apps.notifications.models import Notification
+
+#개별 알림 읽음 처리
+@api_view(["PATCH"])
+@permission_classes([IsAuthenticated])
+def mark_notification_as_read(request: Request, notification_id: int) -> Response:
+    user = request.user
+    assert not isinstance(user, AnonymousUser) # mypy AnonymousUser 오류로 인해 타입 단언 추가
+
+    try:
+        notification = Notification.objects.get(id=notification_id, user=user)
+    except Notification.DoesNotExist:
+        return Response({"detail": "Notification not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    # 이미 읽음 상태인 경우, 추가 업데이트 없이 안내 메시지만 반환
+    if notification.is_read:
+        return Response({"detail": "Notification already read"}, status=status.HTTP_200_OK)
+
+    notification.is_read = True
+    notification.save(update_fields=["is_read"])
+
+    return Response({"detail": "Notification marked as read"}, status=status.HTTP_200_OK)
+
+#전체 알림 읽음 처리
+@api_view(["PATCH"])
+@permission_classes([IsAuthenticated])
+def mark_all_notification_as_read(request: Request) -> Response:
+    user = request.user
+    assert not isinstance(user, AnonymousUser) # mypy AnonymousUser 오류로 인해 타입 단언 추가
+
+    # 해당 사용자의 읽지 않은(is_read=False) 알림을 모두 읽음(True)으로 변경
+    updated_count = Notification.objects.filter(user=user, is_read=False).update(is_read=True)
+    return Response({"detail": f"{updated_count} notifications marked as read."}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #31
- 작업 요약: notifications의 개별/전체 알림 읽음 처리 API 및 테스트코드 작성

## 📄 상세 내용
- [ ] apps/notifications/tests/test_read_views.py 신규 작성
- [ ] apps/notifications/urls/read_urls.py 신규 작성
- [ ] apps/notifications/views/read_views.py 신규 작성
- [ ] configs/urls.py 수정 (개별/전체 알림 읽음처리 URL 라우팅 연결)

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [o] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [o] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
