### PR TITLE
✨ feat(users) : admin 대시보드 회원 탈퇴 사유 추적 api 생성

### DIFF
--- a/apps/users/services/admin_dashboard_services.py
+++ b/apps/users/services/admin_dashboard_services.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from calendar import monthrange
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import List, Literal, Optional, TypedDict, cast
+
+from django.db.models import Count
+from django.db.models.functions import TruncMonth, TruncYear
+from django.utils import timezone
+
+from apps.users.models import Withdrawal
+
+Interval = Literal["month", "year"]
+
+
+class _Row(TypedDict):
+    period: date | datetime
+    count: int
+
+
+def _fmt(p: date | datetime, fmt: str) -> str:
+    """period 문자열로 변환."""
+    d = p.date() if isinstance(p, datetime) else p
+    return d.strftime(fmt)
+
+
+# ------------------------------------------------------
+# 응답 형태
+# ------------------------------------------------------
+@dataclass
+class TrendItem:
+    period: str
+    count: int
+
+
+@dataclass
+class TrendResult:
+    """
+    ---------------------------------------------------------
+    - interval : "month"|"year"
+    - date_from: 포함 시작일
+    - date_to  : 포함 종료일(말일/연말 기준)
+    - total    : 모든 구간 count 합계
+    - items    : 기간별 데이터 리스트
+    ---------------------------------------------------------
+    """
+
+    interval: Interval
+    date_from: str
+    date_to: str
+    total: int
+    items: List[TrendItem]
+
+
+# ------------------------------------------------------
+# 서비스
+# ------------------------------------------------------
+class AdminDashboardStatsService:
+    """
+    ---------------------------------------------------------
+    # 최근 12개월 탈퇴 사유 전체 집계
+    result = AdminDashboardStatsService.get_trends("month")
+
+    # 최근 12개월 특정 사유 집계
+    result = AdminDashboardStatsService.get_trends("month", reason="SPAM")
+
+    # 최근 5년 전체 집계
+    result = AdminDashboardStatsService.get_trends("year")
+    ---------------------------------------------------------
+    """
+
+    @staticmethod
+    def get_trends(interval: Interval, reason: Optional[str] = None) -> TrendResult:
+        today = timezone.localdate()
+
+        # =====================================================
+        # 최근 12개월 월간 통계
+        # =====================================================
+        if interval == "month":
+            months: List[date] = []
+            base = date(today.year, today.month, 1)
+            for i in range(11, -1, -1):
+                y = base.year + (base.month - 1 - i) // 12
+                m = (base.month - 1 - i) % 12 + 1
+                months.append(date(y, m, 1))
+
+            start = months[0]
+            # 다음달의 월초
+            last = months[-1]
+            end = date(last.year + (1 if last.month == 12 else 0), (last.month % 12) + 1, 1)
+
+            # 탈퇴 요청일 쿼리 및 탈퇴 사유 필터링
+            qs = Withdrawal.objects.filter(created_at__date__gte=start, created_at__date__lt=end)
+            if reason:
+                qs = qs.filter(reason=reason)
+
+            rows: List[_Row] = cast(
+                List[_Row],
+                list(qs.annotate(period=TruncMonth("created_at")).values("period").annotate(count=Count("id"))),
+            )
+
+            counts = {_fmt(r["period"], "%Y-%m"): r["count"] for r in rows}
+
+            # 누락 월은 0으로 채움
+            items = [TrendItem(period=m.strftime("%Y-%m"), count=counts.get(m.strftime("%Y-%m"), 0)) for m in months]
+
+            last_day = monthrange(last.year, last.month)[1]
+            human_to = date(last.year, last.month, last_day)
+
+            return TrendResult(
+                interval="month",
+                date_from=start.strftime("%Y-%m-%d"),
+                date_to=human_to.strftime("%Y-%m-%d"),
+                total=sum(i.count for i in items),
+                items=items,
+            )
+
+        # =====================================================
+        # 최근 5년 연간 통계
+        # =====================================================
+        years = [today.year - i for i in range(4, -1, -1)]  # 오름차순
+        start = date(years[0], 1, 1)
+        end = date(years[-1] + 1, 1, 1)
+
+        qs = Withdrawal.objects.filter(created_at__date__gte=start, created_at__date__lt=end)
+        if reason:
+            qs = qs.filter(reason=reason)
+
+        rows = cast(
+            List[_Row],
+            list(qs.annotate(period=TruncYear("created_at")).values("period").annotate(count=Count("id"))),
+        )
+
+        counts = {_fmt(r["period"], "%Y"): r["count"] for r in rows}
+
+        items = [TrendItem(period=str(y), count=counts.get(str(y), 0)) for y in years]
+
+        human_to = date(years[-1], 12, 31)
+
+        return TrendResult(
+            interval="year",
+            date_from=start.strftime("%Y-%m-%d"),
+            date_to=human_to.strftime("%Y-%m-%d"),
+            total=sum(i.count for i in items),
+            items=items,
+        )

--- a/apps/users/tests/test_admin_dashboard.py
+++ b/apps/users/tests/test_admin_dashboard.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import List
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.users.enums import Reason
+from apps.users.models import User, Withdrawal
+from apps.users.services.admin_dashboard_services import AdminDashboardStatsService
+
+DELETE_GRACE_DAYS = 14
+
+
+# ---------------------------------------------------------
+# 공통 베이스
+# ---------------------------------------------------------
+class BaseDashboardTest:
+    admin: User
+    normal_user: User
+    target_reason: str
+    today = timezone.localdate()
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.admin = User.objects.create_user(
+            email="admin@example.com",
+            password="1234",
+            name="관리자",
+            nickname="admin",
+            gender="male",
+            phone_number="01000000000",
+            birthday="1990-01-01",
+            is_active=True,
+            is_staff=True,
+        )
+
+        cls.normal_user = User.objects.create_user(
+            email="normal@example.com",
+            password="1234",
+            name="일반유저",
+            nickname="normal",
+            gender="male",
+            phone_number="01011112222",
+            birthday="1995-01-01",
+            is_active=True,
+        )
+
+        cls.target_reason = Reason.LACK_OF_CONTENT.value
+
+        due_date = cls.today + timedelta(days=DELETE_GRACE_DAYS)
+
+        withdrawals: List[Withdrawal] = []
+        for offset in [0, 1, 5]:
+            dt = cls.today - timedelta(days=30 * offset)
+            withdrawals.append(
+                Withdrawal(
+                    user=cls.normal_user,
+                    reason=cls.target_reason,
+                    reason_detail="컨텐츠 없음",
+                    due_date=due_date,
+                    created_at=datetime(dt.year, dt.month, 15, 14, 0),
+                )
+            )
+        Withdrawal.objects.bulk_create(withdrawals)
+
+
+# ---------------------------------------------------------
+# 어드민 - 대시보드 회원 탈퇴 사유 추적 뷰 테스트
+# ---------------------------------------------------------
+class TestAdminWithdrawalReasonStatsView(BaseDashboardTest, APITestCase):
+    base_url: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        cls.base_url = reverse("users:admin_withdrawal_list_by_reason")
+
+    def test_success(self) -> None:
+        """정상 요청(200) + 12개월 고정 + 총합 3건"""
+        self.client.force_authenticate(self.admin)
+        r = self.client.get(self.base_url, {"reason": self.target_reason})
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+
+        data = r.data["data"]
+        self.assertEqual(data["interval"], "month")
+        self.assertEqual(len(data["items"]), 12)
+        self.assertEqual(sum(i["count"] for i in data["items"]), 3)
+
+    def test_invalid_reason(self) -> None:
+        """유효하지 않은 reason → 400"""
+        self.client.force_authenticate(self.admin)
+        r = self.client.get(self.base_url, {"reason": "INVALID"})
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("유효하지 않은 사유입니다.", r.data["error"])
+
+    def test_forbidden(self) -> None:
+        """staff 권한 없으면 → 403"""
+        self.client.force_authenticate(self.normal_user)
+        r = self.client.get(self.base_url, {"reason": self.target_reason})
+        self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthorized(self) -> None:
+        """인증 없으면 → 401"""
+        r = self.client.get(self.base_url, {"reason": self.target_reason})
+        self.assertEqual(r.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_zero_filled(self) -> None:
+        """데이터 없는 월은 count=0으로 채워져야 함"""
+        self.client.force_authenticate(self.admin)
+        items = self.client.get(self.base_url, {"reason": self.target_reason}).data["data"]["items"]
+        self.assertTrue(any(i["count"] == 0 for i in items))
+
+
+# ---------------------------------------------------------
+# 어드민 - 대시보드 회원 탈퇴 사유 추적 서비스 테스트
+# ---------------------------------------------------------
+class TestAdminDashboardStatsService(BaseDashboardTest, TestCase):
+    def test_month(self) -> None:
+        """최근 12개월 월간 통계: 총합 3, 아이템 12개"""
+        r = AdminDashboardStatsService.get_trends("month", reason=self.target_reason)
+        self.assertEqual(r.total, 3)
+        self.assertEqual(len(r.items), 12)
+
+    def test_year(self) -> None:
+        """최근 5년 연간 통계: 총합 3, 아이템 5개"""
+        r = AdminDashboardStatsService.get_trends("year", reason=self.target_reason)
+        self.assertEqual(r.total, 3)
+        self.assertEqual(len(r.items), 5)
+
+    def test_month_no_reason(self) -> None:
+        """reason=None(전체 집계)도 총합 3 이어야 함"""
+        r = AdminDashboardStatsService.get_trends("month")
+        self.assertEqual(r.total, 3)
+
+    def test_year_interval_coverage(self) -> None:
+        """
+        최근 5년 중 '올해'에만 3건이며 나머지 연도는 0건이어야 함
+        """
+        r = AdminDashboardStatsService.get_trends("year")
+        self.assertEqual(len(r.items), 5)
+        self.assertEqual(r.items[-1].count, 3)
+        for item in r.items[:-1]:
+            self.assertEqual(item.count, 0)

--- a/apps/users/urls/admin_urls.py
+++ b/apps/users/urls/admin_urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from apps.users.views.admin_dashboard_views import AdminWithdrawalReasonStatsView
 from apps.users.views.admin_users_views import (
     AdminUserListView,
     AdminUserRoleUpdateView,
@@ -33,9 +34,17 @@ urlpatterns = [
         AdminUserRestoreView.as_view(),
         name="admin_user_restore",
     ),
+    # --------------------------------------------------------
+    # 어드민 대시보드
+    # --------------------------------------------------------
     path(
         "admin/dashboard/withdrawals/trends",
         WithdrawalTrendsAPIView.as_view(),
         name="withdrawal_trends",
     ),
+    path(
+        "admin/dashboard/withdrawals/stats",
+        AdminWithdrawalReasonStatsView.as_view(),
+        name="admin_withdrawal_list_by_reason",
+    ),  # 회원 탈퇴 사유 추적
 ]

--- a/apps/users/views/admin_dashboard_views.py
+++ b/apps/users/views/admin_dashboard_views.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from apps.core.views import ExceptionHandledAPIView
+from apps.users.enums import Reason
+from apps.users.permissions import IsStaffRole
+from apps.users.services.admin_dashboard_services import AdminDashboardStatsService
+
+
+class AdminWithdrawalReasonStatsView(ExceptionHandledAPIView):
+    permission_classes = [IsAuthenticated, IsStaffRole]
+
+    @extend_schema(
+        tags=["Admin"],
+        operation_id="v1_admin_dashboard_withdrawal_reason_stats",
+        summary="대시보드 - 회원 탈퇴 사유 추적",
+        description="`reason`에 해당하는 탈퇴 사유의 최근 12개월 월별 통계를 반환",
+        parameters=[
+            OpenApiParameter(
+                name="reason",
+                required=True,
+                type=OpenApiTypes.STR,
+                enum=[r.value for r in Reason],
+                location=OpenApiParameter.QUERY,
+                description="탈퇴 사유 코드",
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(description="성공적으로 월별 통계를 반환"),
+            400: OpenApiResponse(description="요청 파라미터 오류"),
+            403: OpenApiResponse(description="관리자 권한 필요"),
+        },
+    )
+    def get(self, request: Request) -> Response:
+        reason_str = request.query_params.get("reason")
+        if not reason_str:
+            return Response({"error": "탈퇴 사유 선택은 필수입니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            reason_enum = Reason(reason_str)
+        except ValueError:
+            return Response({"error": "유효하지 않은 사유입니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # 2) 최근 12개월, 해당 사유만
+        result = AdminDashboardStatsService.get_trends(interval="month", reason=reason_enum.value)
+
+        payload = {
+            "detail": "회원탈퇴 사유 추적 조회에 성공하였습니다.",
+            "data": {
+                "interval": result.interval,
+                "from_date": result.date_from,
+                "to_date": result.date_to,
+                "total_withdrawals": result.total,
+                "items": [{"period": i.period, "count": i.count} for i in result.items],
+            },
+        }
+        return Response(payload, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 어드민 대시보드 탈퇴 사유 통계 API 생성

## 📄 상세 내용
- [x] 대시보드 서비스 생성: AdminDashboardStatsService.get_trends()
       - 월간/연간 집계 분기 

- [x] 대시보드 서비스, 뷰 테스트 생성


## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
