### PR TITLE
Fix : s3 .{ext}확장자 중복케이스 조건문제어

### DIFF
--- a/apps/core/tests/test_s3_uploader.py
+++ b/apps/core/tests/test_s3_uploader.py
@@ -30,23 +30,26 @@ class S3UploaderTests(TestCase):
         self._mock = mock_aws()
         self._mock.start()
 
-        self.bucket: str = "test-bucket"
-        self.region: Literal["ap-northeast-2"] = "ap-northeast-2"
+        self.bucket = "test-bucket"
+        self.region = "ap-northeast-2"
 
         setattr(settings, "AWS_S3_BUCKET_NAME", self.bucket)
         setattr(settings, "AWS_S3_REGION", self.region)
         setattr(settings, "AWS_S3_ACCESS_KEY_ID", "xxx")
         setattr(settings, "AWS_S3_SECRET_ACCESS_KEY", "yyy")
 
-        client = boto3.client("s3", region_name=self.region)
-        client.create_bucket(
+        # mock 시작 후에 클라이언트를 다시 생성
+        S3Uploader.s3_client = boto3.client("s3", region_name=self.region)
+
+        # 버킷 생성
+        S3Uploader.s3_client.create_bucket(
             Bucket=self.bucket,
             CreateBucketConfiguration={"LocationConstraint": self.region},
         )
 
+        # 속성들 반영
         S3Uploader.BUCKET_NAME = self.bucket
         S3Uploader.REGION_NAME = self.region
-        S3Uploader.s3_client = client
         S3Uploader.S3_BASE_URL = f"https://{self.bucket}.s3.{self.region}.amazonaws.com/"
 
     def tearDown(self) -> None:

--- a/apps/core/tests/test_s3_uploader.py
+++ b/apps/core/tests/test_s3_uploader.py
@@ -102,6 +102,11 @@ class S3UploaderTests(TestCase):
             files=files,
         )
 
+        # ✅ 출력 추가
+        import json
+
+        print("\n[DEBUG] Presigned URL result:\n", json.dumps(result, indent=2, ensure_ascii=False))
+
         self.assertEqual(len(result), 1)
         item = result[0]
         self.assertIn("url", item)

--- a/apps/core/tests/test_s3_uploader.py
+++ b/apps/core/tests/test_s3_uploader.py
@@ -108,7 +108,7 @@ class S3UploaderTests(TestCase):
         # ✅ 출력 추가
         import json
 
-        print("\n[DEBUG] Presigned URL result:\n", json.dumps(result, indent=2, ensure_ascii=False))
+        # print("\n[DEBUG] Presigned URL result:\n", json.dumps(result, indent=2, ensure_ascii=False))
 
         self.assertEqual(len(result), 1)
         item = result[0]

--- a/apps/core/utils/s3_uploader.py
+++ b/apps/core/utils/s3_uploader.py
@@ -138,7 +138,10 @@ class S3Uploader:
 
             ext = cast(str, file_name).rsplit(".", 1)[-1].lower()
 
-            key = f"{prefix}{uuid.uuid4()}_{file_name}.{ext}"
+            if file_name and "." in file_name:
+                key = f"{prefix}{uuid.uuid4()}_{file_name}"
+            else:
+                key = f"{prefix}{uuid.uuid4()}_{file_name}.{ext}"
 
             try:
                 presigned_post = cls.s3_client.generate_presigned_post(

--- a/apps/studies/views/s3_presign.py
+++ b/apps/studies/views/s3_presign.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -73,6 +75,8 @@ class StudyNoteS3PresignedView(APIView):
         serializer.is_valid(raise_exception=True)
 
         files = serializer.validated_data["files"]
+
+        presigned_urls: list[dict[str, Any]] = []
 
         for f in files:
             file_name = f.get("file_name")


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호:
- 작업 중 프론트에서 presigned url 테스트 결과가 이상하다는 제보를 받고 확인하며 수정함.
 s3 미연동 상태에서 어떤 라이브러리와 연동해서 테스트한 상황인지 명확히 모르지만 본인 로컬 moto_aws 기준 테스트 통과(print 결과로 uuid 변경되며 제대로 찍힘, 확장자 중복x 등)

## 📄 상세 내용
- .{ext} 조건문으로 중복되는 경우 배제

- 리스트 선언없이 for 문 돌며 프리사인을 생성만하던 부분 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
