### PR TITLE
🐛 Fix : 웹소켓 컨슈머 UUID 리팩토링 및 스웨거 문서 업데이트 (프론트 요청사항)

### DIFF
--- a/apps/chat/consumers.py
+++ b/apps/chat/consumers.py
@@ -2,6 +2,7 @@
 
 import json
 from typing import Any, cast
+from uuid import UUID
 
 from channels.db import database_sync_to_async
 from channels.generic.websocket import (
@@ -16,13 +17,13 @@ from apps.users.models.user import User
 
 
 class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
-    study_group_id: int
+    study_group_uuid: UUID
     room_group_name: str
     user: AbstractBaseUser
 
     async def connect(self) -> None:
-        self.study_group_id = self.scope["url_route"]["kwargs"]["study_group_id"]
-        self.room_group_name = f"chat_{self.study_group_id}"
+        self.study_group_uuid = self.scope["url_route"]["kwargs"]["study_group_uuid"]
+        self.room_group_name = f"chat_{self.study_group_uuid}"
         self.user = self.scope["user"]
 
         if not await self.is_valid_study_group() or not await self.is_group_member(self.user):
@@ -48,10 +49,13 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
         """
         Marks all messages in the current study group as read for the current user.
         """
-        latest_message = await ChatMessage.objects.filter(study_group_id=self.study_group_id).alast()
+        # Retrieve the StudyGroup object using its UUID
+        study_group = await StudyGroup.objects.aget(uuid=self.study_group_uuid)
+
+        latest_message = await ChatMessage.objects.filter(study_group=study_group).alast()
         if latest_message:
             await LastReadMessage.objects.aupdate_or_create(
-                study_group_id=self.study_group_id,
+                study_group=study_group,
                 user=self.user,
                 defaults={"message": latest_message},
             )
@@ -90,18 +94,18 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
             )
 
     async def is_valid_study_group(self) -> bool:
-        return await StudyGroup.objects.filter(id=self.study_group_id).aexists()
+        return await StudyGroup.objects.filter(uuid=self.study_group_uuid).aexists()
 
     async def is_group_member(self, user: AbstractBaseUser) -> bool:
         if not user.is_authenticated or not isinstance(user, get_user_model()):
             return False
-        return await GroupMember.objects.filter(study_group_id=self.study_group_id, user=user).aexists()
+        return await GroupMember.objects.filter(study_group__uuid=self.study_group_uuid, user=user).aexists()
 
     async def create_chat_message(self, user: AbstractBaseUser, content: str) -> None:
         """
         Asynchronously creates a chat message in the database.
         """
-        study_group = await StudyGroup.objects.aget(id=self.study_group_id)
+        study_group = await StudyGroup.objects.aget(uuid=self.study_group_uuid)
         await ChatMessage.objects.acreate(
             sender=cast(User, user),
             study_group=study_group,
@@ -139,5 +143,5 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
         Closes the WebSocket connection.
         """
         disconnected_study_group_id = event.get("study_group_id")
-        if disconnected_study_group_id == self.study_group_id:
+        if disconnected_study_group_id == self.study_group_uuid:
             await self.close(code=4001)

--- a/apps/chat/routing.py
+++ b/apps/chat/routing.py
@@ -1,0 +1,7 @@
+from django.urls import re_path
+
+from apps.chat.consumers import ChatConsumer
+
+websocket_urlpatterns = [
+    re_path(r"ws/chat/(?P<study_group_uuid>[0-9a-f-]+)/$", ChatConsumer.as_asgi()),
+]

--- a/apps/chat/tests/test_chat_consumers.py
+++ b/apps/chat/tests/test_chat_consumers.py
@@ -72,17 +72,17 @@ class ChatConsumerTest(TransactionTestCase):
         # 2. Set up WebSocket communicators for both users
         communicator1 = WebsocketCommunicator(
             ChatConsumer.as_asgi(),
-            f"/ws/study-groups/{study_group.id}/chat/",
+            f"/ws/study-groups/{study_group.uuid}/chat/",
         )
         communicator1.scope["user"] = user1
-        communicator1.scope["url_route"] = {"kwargs": {"study_group_id": study_group.id}}
+        communicator1.scope["url_route"] = {"kwargs": {"study_group_uuid": str(study_group.uuid)}}
 
         communicator2 = WebsocketCommunicator(
             ChatConsumer.as_asgi(),
-            f"/ws/study-groups/{study_group.id}/chat/",
+            f"/ws/study-groups/{study_group.uuid}/chat/",
         )
         communicator2.scope["user"] = user2
-        communicator2.scope["url_route"] = {"kwargs": {"study_group_id": study_group.id}}
+        communicator2.scope["url_route"] = {"kwargs": {"study_group_uuid": str(study_group.uuid)}}
 
         # 3. Connect both users to the WebSocket
         connected1, _ = await communicator1.connect()
@@ -138,10 +138,10 @@ class ChatConsumerTest(TransactionTestCase):
 
         communicator = WebsocketCommunicator(
             ChatConsumer.as_asgi(),
-            f"/ws/study-groups/{study_group.id}/chat/",
+            f"/ws/study-groups/{study_group.uuid}/chat/",
         )
         communicator.scope["user"] = user
-        communicator.scope["url_route"] = {"kwargs": {"study_group_id": study_group.id}}
+        communicator.scope["url_route"] = {"kwargs": {"study_group_uuid": str(study_group.uuid)}}
 
         connected, subprotocol = await communicator.connect()
         self.assertTrue(connected)
@@ -159,11 +159,11 @@ class ChatConsumerTest(TransactionTestCase):
 
         communicator = WebsocketCommunicator(
             ChatConsumer.as_asgi(),
-            f"/ws/study-groups/{study_group.id}/chat/",
+            f"/ws/study-groups/{study_group.uuid}/chat/",
         )
         # User is not set, so it will be an AnonymousUser
         communicator.scope["user"] = AnonymousUser()
-        communicator.scope["url_route"] = {"kwargs": {"study_group_id": study_group.id}}
+        communicator.scope["url_route"] = {"kwargs": {"study_group_uuid": str(study_group.uuid)}}
 
         connected, subprotocol = await communicator.connect()
         self.assertFalse(connected)
@@ -181,14 +181,14 @@ class ChatConsumerTest(TransactionTestCase):
             gender="M",
             birthday="2000-01-01",
         )
-        # Use a non-existent study_group_id
-        invalid_study_group_id = 99999
+        # Use a non-existent study_group_uuid
+        invalid_study_group_uuid = "00000000-0000-0000-0000-000000000000"
 
         communicator = WebsocketCommunicator(
             ChatConsumer.as_asgi(),
-            f"/ws/study-groups/{invalid_study_group_id}/chat/",
+            f"/ws/study-groups/{invalid_study_group_uuid}/chat/",
         )
-        communicator.scope["url_route"] = {"kwargs": {"study_group_id": invalid_study_group_id}}
+        communicator.scope["url_route"] = {"kwargs": {"study_group_uuid": invalid_study_group_uuid}}
         communicator.scope["user"] = user
         connected, subprotocol = await communicator.connect()
         self.assertFalse(connected)
@@ -214,10 +214,10 @@ class ChatConsumerTest(TransactionTestCase):
         )
         communicator = WebsocketCommunicator(
             ChatConsumer.as_asgi(),
-            f"/ws/study-groups/{study_group.id}/chat/",
+            f"/ws/study-groups/{study_group.uuid}/chat/",
         )
         communicator.scope["user"] = user
-        communicator.scope["url_route"] = {"kwargs": {"study_group_id": study_group.id}}
+        communicator.scope["url_route"] = {"kwargs": {"study_group_uuid": str(study_group.uuid)}}
         connected, subprotocol = await communicator.connect()
         self.assertFalse(connected)
         self.assertEqual(subprotocol, 403)
@@ -254,7 +254,7 @@ class ChatConsumerTest(TransactionTestCase):
         # 3. Directly instantiate the consumer and call the method
         consumer = ChatConsumer()
         consumer.scope = {"user": user}
-        consumer.study_group_id = study_group.id
+        consumer.study_group_uuid = study_group.uuid
         consumer.user = user
 
         await consumer.mark_messages_as_read()

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -30,10 +30,10 @@ class ChatMessageListView(APIView):
         """,
         parameters=[
             OpenApiParameter(
-                name="study_group_id",
-                type=int,
+                name="study_group_uuid",
+                type=str,
                 location=OpenApiParameter.PATH,
-                description="그룹 ID",
+                description="그룹 UUID",
                 required=True,
             ),
             OpenApiParameter(


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: 
- chat 앱의 웹소켓 컨슈머(ChatConsumer)가 스터디 그룹 식별자로 int ID 대신 UUID를 사용하도록 리팩토링하고, 관련 API 문서(Swagger)를 업데이트
- 프론트엔드와의 일관된 API 통신을 제공하고, 웹소켓 기능이 활성화될 때 UUID 기반으로 올바르게 동작하도록 준비하기 위함
- 웹소켓 라우팅 활성화 관련 작업완료 -> 현재 PR 병합되면 리베이스 및 테스트 후 PR 요청 예정

## 📄 상세 내용
- [x] API 식별자 불일치:
- 기존 REST API(ChatRoomListView, ChatMessageListView)는 스터디 그룹 식별자로 UUID를 사용
- 웹소켓 컨슈머(ChatConsumer)는 내부적으로 int ID를 기대
- 식별자 타입의 불일치는 프론트엔드 개발팀에 혼란을 야기하고, 일관된 API 사용을 방해
- [x] Swagger 문서 오류: 
- ChatMessageListView의 Swagger 문서가 study_group_id를 int 타입으로 잘못 명시

- [x] 해결 방안 및 변경 내역:
1. apps/chat/routing.py 파일 생성:
- 웹소켓 연결을 위한 URL 패턴을 uuid 기반으로 정의하는 apps/chat/routing.py 파일을 새로 생성
- re_path(r"ws/chat/(?P<study_group_uuid>[0-9a-f-]+)/$", ChatConsumer.as_asgi())

2. apps/chat/consumers.py 수정:
- ChatConsumer 내부에서 스터디 그룹 식별자를 study_group_id: int에서 study_group_uuid: UUID로 변경
- URL kwargs 접근(self.scope["url_route"]["kwargs"]["study_group_uuid"]) 및 모든 내부 데이터베이스 쿼리(filter(id=...) -> filter(uuid=...) 또는 study_group=study_group_object)를 uuid 기반으로 수정

3. apps/chat/views.py (Swagger) 수정:
       - ChatMessageListView의 @extend_schema 데코레이터 내 OpenApiParameter를 name="study_group_uuid", type=str로 수정하여 Swagger 문서가 uuid를 올바르게 표시 (format="uuid"는 drf_spectacular에서 지원하지 않아 제거)

4. apps/chat/tests/test_chat_consumers.py 수정:
- 컨슈머의 uuid 변경사항에 맞춰 테스트 코드를 업데이트 -> WebsocketCommunicator 설정 및 ChatConsumer 인스턴스 생성 시 study_group_uuid를 사용하도록 수정
- mark_messages_as_read 로직 테스트 시 IntegrityError를 해결하기 위해LastReadMessage.objects.select_related("message").aget(...)을 사용하도록 수정

- [x] 변경 이유:
- API 일관성 확보: REST API와 웹소켓 모두 StudyGroup 식별자로 uuid를 사용하도록 통일하여 API의 일관성을 확보
- 프론트엔드 개발 편의성 증대: 프론트엔드 개발자가 int와 uuid를 혼용하는 혼란 없이 uuid 하나로만 작업할 수 있도록 지원
- 문서 정합성: Swagger 문서를 실제 API 동작과 일치시켜 개발자 간의 오해를 줄임

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
