### PR TITLE
✨ feat(users): Admin 대시보드 회원탈퇴 사유 분포 API 생성

### DIFF
--- a/apps/users/serializers/admin_dashboard_serializers.py
+++ b/apps/users/serializers/admin_dashboard_serializers.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any
+
+from rest_framework import serializers
+
+from apps.users.services.admin_dashboard_services import (
+    ReasonItem,
+    TrendItem,
+    TrendResult,
+)
+
+
+class WithdrawalPeriodItemSerializer(serializers.Serializer[dict[str, Any]]):
+    """
+    기간별(월/연) 탈퇴 건수 아이템 Serializer
+    """
+
+    period = serializers.CharField()
+    count = serializers.IntegerField()
+
+
+class WithdrawalReasonItemSerializer(serializers.Serializer[dict[str, Any]]):
+    """
+    단일 탈퇴 사유 통계 아이템 Serializer
+    """
+
+    reason_code = serializers.CharField()
+    reason_label = serializers.CharField()
+    count = serializers.IntegerField()
+    percentage = serializers.FloatField()
+
+
+class AdminWithdrawalReasonTrendResponseSerializer(serializers.Serializer[TrendResult[TrendItem]]):
+    """
+    탈퇴 사유 추적(월/연 트렌드) 조회 응답 Serializer
+    """
+
+    interval = serializers.ChoiceField(choices=["month", "year"])
+    from_date = serializers.DateField()
+    to_date = serializers.DateField()
+    total_withdrawals = serializers.IntegerField()
+    items = WithdrawalPeriodItemSerializer(many=True)
+
+
+class AdminWithdrawalReasonDistributionResponseSerializer(serializers.Serializer[TrendResult[ReasonItem]]):
+    """
+    탈퇴 사유 분포(전체 기간) 조회 응답 Serializer
+    """
+
+    interval = serializers.ChoiceField(choices=["all_time"])
+    from_date = serializers.DateField()
+    to_date = serializers.DateField()
+    total_withdrawals = serializers.IntegerField()
+    items = WithdrawalReasonItemSerializer(many=True)

--- a/apps/users/services/admin_dashboard_services.py
+++ b/apps/users/services/admin_dashboard_services.py
@@ -3,15 +3,30 @@ from __future__ import annotations
 from calendar import monthrange
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import List, Literal, Optional, TypedDict, cast
+from typing import (
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    TypedDict,
+    TypeVar,
+    cast,
+)
 
 from django.db.models import Count
 from django.db.models.functions import TruncMonth, TruncYear
 from django.utils import timezone
 
+from apps.users.enums import Reason
 from apps.users.models import Withdrawal
 
-Interval = Literal["month", "year"]
+Interval = Literal["month", "year", "all_time"]
+
+
+class BaseItem(Protocol):
+    count: int
 
 
 class _Row(TypedDict):
@@ -25,6 +40,9 @@ def _fmt(p: date | datetime, fmt: str) -> str:
     return d.strftime(fmt)
 
 
+TItem = TypeVar("TItem", bound=BaseItem)
+
+
 # ------------------------------------------------------
 # 응답 형태
 # ------------------------------------------------------
@@ -35,22 +53,30 @@ class TrendItem:
 
 
 @dataclass
-class TrendResult:
+class ReasonItem:
+    reason_code: str
+    reason_label: str
+    count: int
+    percentage: float
+
+
+@dataclass
+class TrendResult(Generic[TItem]):
     """
     ---------------------------------------------------------
-    - interval : "month"|"year"
-    - date_from: 포함 시작일
-    - date_to  : 포함 종료일(말일/연말 기준)
-    - total    : 모든 구간 count 합계
-    - items    : 기간별 데이터 리스트
+    - interval : "month"|"year"|"all_time"
+    - from_date: 포함 시작일
+    - to_date  : 포함 종료일(말일/연말 기준)
+    - total_withdrawals : 집계 구간 총 탈퇴 수
+    - items    : 데이터 리스트(월/연 집계 or 사유별 분포)
     ---------------------------------------------------------
     """
 
     interval: Interval
-    date_from: str
-    date_to: str
-    total: int
-    items: List[TrendItem]
+    from_date: str
+    to_date: str
+    total_withdrawals: int
+    items: List[TItem]
 
 
 # ------------------------------------------------------
@@ -67,11 +93,14 @@ class AdminDashboardStatsService:
 
     # 최근 5년 전체 집계
     result = AdminDashboardStatsService.get_trends("year")
+
+    # 전체 기간 사유별 분포
+    result = AdminDashboardStatsService.get_reason_distribution_all_time()
     ---------------------------------------------------------
     """
 
     @staticmethod
-    def get_trends(interval: Interval, reason: Optional[str] = None) -> TrendResult:
+    def get_trends(interval: Interval, reason: Optional[str] = None) -> TrendResult[TrendItem]:
         today = timezone.localdate()
 
         # =====================================================
@@ -110,9 +139,9 @@ class AdminDashboardStatsService:
 
             return TrendResult(
                 interval="month",
-                date_from=start.strftime("%Y-%m-%d"),
-                date_to=human_to.strftime("%Y-%m-%d"),
-                total=sum(i.count for i in items),
+                from_date=start.strftime("%Y-%m-%d"),
+                to_date=human_to.strftime("%Y-%m-%d"),
+                total_withdrawals=sum(i.count for i in items),
                 items=items,
             )
 
@@ -140,8 +169,84 @@ class AdminDashboardStatsService:
 
         return TrendResult(
             interval="year",
-            date_from=start.strftime("%Y-%m-%d"),
-            date_to=human_to.strftime("%Y-%m-%d"),
-            total=sum(i.count for i in items),
+            from_date=start.strftime("%Y-%m-%d"),
+            to_date=human_to.strftime("%Y-%m-%d"),
+            total_withdrawals=sum(i.count for i in items),
+            items=items,
+        )
+
+    @staticmethod
+    def get_reason_distribution_all_time(
+        date_from: Optional[date] = None,
+        date_to: Optional[date] = None,
+    ) -> TrendResult[ReasonItem]:
+        """
+        전체 기간(혹은 지정 범위)에서 탈퇴 사유별 집계 및 퍼센트
+        """
+        base_qs = Withdrawal.objects.all()
+
+        # 데이터가 전혀 없으면 전체 0카운트로
+        if not base_qs.exists():
+            today = timezone.localdate()
+            return TrendResult(
+                interval="all_time",
+                from_date=str(today),
+                to_date=str(today),
+                total_withdrawals=0,
+                items=[
+                    ReasonItem(
+                        reason_code=m.value,
+                        reason_label=m.label,
+                        count=0,
+                        percentage=0.0,
+                    )
+                    for m in Reason
+                ],
+            )
+
+        # 조회 시작일/종료일 없으면 Withdrawal created_at 기준
+        if date_from is None:
+            first = base_qs.order_by("created_at").values_list("created_at", flat=True).first()
+            date_from = first.date() if first else timezone.localdate()
+        if date_to is None:
+            last = base_qs.order_by("-created_at").values_list("created_at", flat=True).first()
+            date_to = last.date() if last else timezone.localdate()
+
+        qs = base_qs.filter(created_at__date__gte=date_from, created_at__date__lte=date_to)
+
+        # 사유별 집계 (NULL → OTHER로 치환)
+        rows = qs.values("reason").annotate(count=Count("id"))
+        counts_map: Dict[str, int] = {}
+        for r in rows:
+            code = r["reason"] or Reason.OTHER.value
+            counts_map[code] = r["count"]
+
+        all_codes: List[str] = [m.value for m in Reason]
+
+        value_to_label: Dict[str, str] = dict(Reason.choices)
+
+        total = sum(counts_map.get(code, 0) for code in all_codes)
+
+        items: List[ReasonItem] = []
+        for code in all_codes:
+            c = counts_map.get(code, 0)
+            pct = round((c / total * 100.0), 1) if total else 0.0
+            items.append(
+                ReasonItem(
+                    reason_code=code,
+                    reason_label=value_to_label.get(code, Reason.OTHER.label),
+                    count=c,
+                    percentage=pct,
+                )
+            )
+
+        # 기본 정렬: count 내림차순 → 동일 시 code 오름차순
+        items.sort(key=lambda x: (-x.count, x.reason_code))
+
+        return TrendResult(
+            interval="all_time",
+            from_date=date_from.strftime("%Y-%m-%d"),
+            to_date=date_to.strftime("%Y-%m-%d"),
+            total_withdrawals=total,
             items=items,
         )

--- a/apps/users/tests/test_admin_dashboard.py
+++ b/apps/users/tests/test_admin_dashboard.py
@@ -17,12 +17,13 @@ DELETE_GRACE_DAYS = 14
 
 
 # ---------------------------------------------------------
-# 공통 베이스
+# 공통 클래스
 # ---------------------------------------------------------
 class BaseDashboardTest:
     admin: User
     normal_user: User
     target_reason: str
+    url: str
     today = timezone.localdate()
 
     @classmethod
@@ -66,6 +67,7 @@ class BaseDashboardTest:
                     created_at=datetime(dt.year, dt.month, 15, 14, 0),
                 )
             )
+
         Withdrawal.objects.bulk_create(withdrawals)
 
 
@@ -73,46 +75,61 @@ class BaseDashboardTest:
 # 어드민 - 대시보드 회원 탈퇴 사유 추적 뷰 테스트
 # ---------------------------------------------------------
 class TestAdminWithdrawalReasonStatsView(BaseDashboardTest, APITestCase):
-    base_url: str
 
     @classmethod
     def setUpTestData(cls) -> None:
         super().setUpTestData()
-        cls.base_url = reverse("users:admin_withdrawal_list_by_reason")
+        cls.url = reverse(
+            "users:admin_withdrawal_list_by_reason",
+            kwargs={"reason": cls.target_reason},
+        )
 
     def test_success(self) -> None:
-        """정상 요청(200) + 12개월 고정 + 총합 3건"""
         self.client.force_authenticate(self.admin)
-        r = self.client.get(self.base_url, {"reason": self.target_reason})
-        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        r = self.client.get(self.url)
 
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
         data = r.data["data"]
+
         self.assertEqual(data["interval"], "month")
         self.assertEqual(len(data["items"]), 12)
         self.assertEqual(sum(i["count"] for i in data["items"]), 3)
 
     def test_invalid_reason(self) -> None:
-        """유효하지 않은 reason → 400"""
+        """
+        유효하지 않은 reason → 400 에러 반환
+        """
         self.client.force_authenticate(self.admin)
-        r = self.client.get(self.base_url, {"reason": "INVALID"})
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        url = reverse(
+            "users:admin_withdrawal_list_by_reason",
+            kwargs={"reason": "INVALID"},
+        )
+        r = self.client.get(url)
+
+        self.assertEqual(r.status_code, 400)
         self.assertIn("유효하지 않은 사유입니다.", r.data["error"])
 
     def test_forbidden(self) -> None:
-        """staff 권한 없으면 → 403"""
+        """
+        staff 권한이 없으면 → 403 반환
+        """
         self.client.force_authenticate(self.normal_user)
-        r = self.client.get(self.base_url, {"reason": self.target_reason})
-        self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
+        r = self.client.get(self.url)
+        self.assertEqual(r.status_code, 403)
 
     def test_unauthorized(self) -> None:
-        """인증 없으면 → 401"""
-        r = self.client.get(self.base_url, {"reason": self.target_reason})
-        self.assertEqual(r.status_code, status.HTTP_401_UNAUTHORIZED)
+        """
+        인증 없이 접근 → 401 반환
+        """
+        r = self.client.get(self.url)
+        self.assertEqual(r.status_code, 401)
 
     def test_zero_filled(self) -> None:
-        """데이터 없는 월은 count=0으로 채워져야 함"""
+        """
+        12개월 중 데이터가 없는 달은 count=0 으로 채워져야 함
+        """
         self.client.force_authenticate(self.admin)
-        items = self.client.get(self.base_url, {"reason": self.target_reason}).data["data"]["items"]
+        items = self.client.get(self.url).data["data"]["items"]
         self.assertTrue(any(i["count"] == 0 for i in items))
 
 
@@ -120,29 +137,39 @@ class TestAdminWithdrawalReasonStatsView(BaseDashboardTest, APITestCase):
 # 어드민 - 대시보드 회원 탈퇴 사유 추적 서비스 테스트
 # ---------------------------------------------------------
 class TestAdminDashboardStatsService(BaseDashboardTest, TestCase):
+
     def test_month(self) -> None:
-        """최근 12개월 월간 통계: 총합 3, 아이템 12개"""
+        """
+        최근 12개월 월간 통계 테스트
+        """
         r = AdminDashboardStatsService.get_trends("month", reason=self.target_reason)
         self.assertEqual(r.total, 3)
         self.assertEqual(len(r.items), 12)
 
     def test_year(self) -> None:
-        """최근 5년 연간 통계: 총합 3, 아이템 5개"""
+        """
+        최근 5년 연간 통계 테스트
+        """
         r = AdminDashboardStatsService.get_trends("year", reason=self.target_reason)
         self.assertEqual(r.total, 3)
         self.assertEqual(len(r.items), 5)
 
     def test_month_no_reason(self) -> None:
-        """reason=None(전체 집계)도 총합 3 이어야 함"""
+        """
+        reason=None (전체 집계)
+        """
         r = AdminDashboardStatsService.get_trends("month")
         self.assertEqual(r.total, 3)
 
     def test_year_interval_coverage(self) -> None:
         """
-        최근 5년 중 '올해'에만 3건이며 나머지 연도는 0건이어야 함
+        - 최근 5년 중 올해(period[-1])에만 3건 존재해야 함
+        - 나머지 연도는 0건이어야 함
         """
         r = AdminDashboardStatsService.get_trends("year")
+
         self.assertEqual(len(r.items), 5)
         self.assertEqual(r.items[-1].count, 3)
+
         for item in r.items[:-1]:
             self.assertEqual(item.count, 0)

--- a/apps/users/tests/test_admin_dashboard.py
+++ b/apps/users/tests/test_admin_dashboard.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import List
 
 from django.test import TestCase
@@ -23,7 +23,6 @@ class BaseDashboardTest:
     admin: User
     normal_user: User
     target_reason: str
-    url: str
     today = timezone.localdate()
 
     @classmethod
@@ -75,61 +74,46 @@ class BaseDashboardTest:
 # 어드민 - 대시보드 회원 탈퇴 사유 추적 뷰 테스트
 # ---------------------------------------------------------
 class TestAdminWithdrawalReasonStatsView(BaseDashboardTest, APITestCase):
+    base_url: str
 
     @classmethod
     def setUpTestData(cls) -> None:
         super().setUpTestData()
-        cls.url = reverse(
-            "users:admin_withdrawal_list_by_reason",
-            kwargs={"reason": cls.target_reason},
-        )
+        cls.base_url = reverse("users:admin_withdrawal_list_by_reason")
 
     def test_success(self) -> None:
+        """정상 요청(200) + 12개월 고정 + 총합 3건"""
         self.client.force_authenticate(self.admin)
-        r = self.client.get(self.url)
-
+        r = self.client.get(self.base_url, {"reason": self.target_reason})
         self.assertEqual(r.status_code, status.HTTP_200_OK)
-        data = r.data["data"]
 
+        data = r.data["data"]
         self.assertEqual(data["interval"], "month")
         self.assertEqual(len(data["items"]), 12)
         self.assertEqual(sum(i["count"] for i in data["items"]), 3)
 
     def test_invalid_reason(self) -> None:
-        """
-        유효하지 않은 reason → 400 에러 반환
-        """
+        """유효하지 않은 reason → 400"""
         self.client.force_authenticate(self.admin)
-        url = reverse(
-            "users:admin_withdrawal_list_by_reason",
-            kwargs={"reason": "INVALID"},
-        )
-        r = self.client.get(url)
-
-        self.assertEqual(r.status_code, 400)
+        r = self.client.get(self.base_url, {"reason": "INVALID"})
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("유효하지 않은 사유입니다.", r.data["error"])
 
     def test_forbidden(self) -> None:
-        """
-        staff 권한이 없으면 → 403 반환
-        """
+        """staff 권한 없으면 → 403"""
         self.client.force_authenticate(self.normal_user)
-        r = self.client.get(self.url)
-        self.assertEqual(r.status_code, 403)
+        r = self.client.get(self.base_url, {"reason": self.target_reason})
+        self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_unauthorized(self) -> None:
-        """
-        인증 없이 접근 → 401 반환
-        """
-        r = self.client.get(self.url)
-        self.assertEqual(r.status_code, 401)
+        """인증 없으면 → 401"""
+        r = self.client.get(self.base_url, {"reason": self.target_reason})
+        self.assertEqual(r.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_zero_filled(self) -> None:
-        """
-        12개월 중 데이터가 없는 달은 count=0 으로 채워져야 함
-        """
+        """데이터 없는 월은 count=0으로 채워져야 함"""
         self.client.force_authenticate(self.admin)
-        items = self.client.get(self.url).data["data"]["items"]
+        items = self.client.get(self.base_url, {"reason": self.target_reason}).data["data"]["items"]
         self.assertTrue(any(i["count"] == 0 for i in items))
 
 
@@ -137,39 +121,189 @@ class TestAdminWithdrawalReasonStatsView(BaseDashboardTest, APITestCase):
 # 어드민 - 대시보드 회원 탈퇴 사유 추적 서비스 테스트
 # ---------------------------------------------------------
 class TestAdminDashboardStatsService(BaseDashboardTest, TestCase):
-
     def test_month(self) -> None:
-        """
-        최근 12개월 월간 통계 테스트
-        """
+        """최근 12개월 월간 통계: 총합 3, 아이템 12개"""
         r = AdminDashboardStatsService.get_trends("month", reason=self.target_reason)
-        self.assertEqual(r.total, 3)
+        self.assertEqual(r.total_withdrawals, 3)
         self.assertEqual(len(r.items), 12)
 
     def test_year(self) -> None:
-        """
-        최근 5년 연간 통계 테스트
-        """
+        """최근 5년 연간 통계: 총합 3, 아이템 5개"""
         r = AdminDashboardStatsService.get_trends("year", reason=self.target_reason)
-        self.assertEqual(r.total, 3)
+        self.assertEqual(r.total_withdrawals, 3)
         self.assertEqual(len(r.items), 5)
 
     def test_month_no_reason(self) -> None:
-        """
-        reason=None (전체 집계)
-        """
+        """reason=None(전체 집계)도 총합 3 이어야 함"""
         r = AdminDashboardStatsService.get_trends("month")
-        self.assertEqual(r.total, 3)
+        self.assertEqual(r.total_withdrawals, 3)
 
     def test_year_interval_coverage(self) -> None:
         """
-        - 최근 5년 중 올해(period[-1])에만 3건 존재해야 함
-        - 나머지 연도는 0건이어야 함
+        최근 5년 중 '올해'에만 3건이며 나머지 연도는 0건이어야 함
         """
         r = AdminDashboardStatsService.get_trends("year")
-
         self.assertEqual(len(r.items), 5)
         self.assertEqual(r.items[-1].count, 3)
-
         for item in r.items[:-1]:
             self.assertEqual(item.count, 0)
+
+
+# ---------------------------------------------------------
+# 어드민 - 대시보드 회원 탈퇴 사유 분포(전체 기간) 뷰 테스트
+# ---------------------------------------------------------
+class TestAdminWithdrawalReasonStatsAllTimeView(BaseDashboardTest, APITestCase):
+    base_url: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        cls.base_url = reverse("users:admin_withdrawal_reason_distribution")
+
+        today = cls.today
+        due = today + timedelta(days=DELETE_GRACE_DAYS)
+
+        extra: List[Withdrawal] = []
+        extra.append(
+            Withdrawal(
+                user=cls.normal_user,
+                reason=Reason.POOR_SERVICE_QUALITY.value,
+                reason_detail="품질 불만",
+                due_date=due,
+                created_at=datetime(today.year, today.month, 5, 10, 0),
+            )
+        )
+        extra.append(
+            Withdrawal(
+                user=cls.normal_user,
+                reason=Reason.PRIVACY_CONCERNS.value,
+                reason_detail=" 보안 우려",
+                due_date=due,
+                created_at=datetime(today.year, max(1, today.month - 2), 20, 11, 0),
+            )
+        )
+
+        two_years_ago = today.replace(year=today.year - 2)
+        extra.append(
+            Withdrawal(
+                user=cls.normal_user,
+                reason=Reason.LACK_OF_INTEREST.value,
+                reason_detail="관심 하락",
+                due_date=due,
+                created_at=datetime(two_years_ago.year, two_years_ago.month, 10, 9, 0),
+            )
+        )
+        Withdrawal.objects.bulk_create(extra)
+
+    # ---------------------------
+    # 성공: 200
+    # ---------------------------
+    def test_success_all_time(self) -> None:
+        """정상 요청(200) + interval=all_time + 전체 합계/아이템 유효성"""
+        self.client.force_authenticate(self.admin)
+        r = self.client.get(self.base_url)
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+
+        data = r.data["data"]
+        self.assertEqual(data["interval"], "all_time")
+        self.assertIn("from_date", data)
+        self.assertIn("to_date", data)
+        self.assertIn("items", data)
+
+        items = data["items"]
+        self.assertEqual(len(items), len(Reason))
+
+        self.assertEqual(
+            data["total_withdrawals"],
+            sum(i["count"] for i in items),
+        )
+
+        sample = items[0]
+        self.assertIn("reason_code", sample)
+        self.assertIn("reason_label", sample)
+        self.assertIn("count", sample)
+        self.assertIn("percentage", sample)
+
+    # ---------------------------
+    # 날짜 필터: 200
+    # ---------------------------
+    def test_date_range_filters(self) -> None:
+        """date_from/date_to로 범위 제한 시, 범위 밖 데이터가 제외되는지 확인"""
+        self.client.force_authenticate(self.admin)
+
+        # 범위를 '작년 1월 1일 ~ 오늘'로 설정
+        today = self.today
+        date_from = date(today.year - 1, 1, 1).isoformat()
+        date_to = today.isoformat()
+
+        r = self.client.get(self.base_url, {"date_from": date_from, "date_to": date_to})
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+
+        data = r.data["data"]
+        items = data["items"]
+        total = data["total_withdrawals"]
+
+        self.assertEqual(total, 6)
+        self.assertEqual(total, sum(i["count"] for i in items))
+
+        # 퍼센트는 total>0이면 0~100 사이
+        for i in items:
+            self.assertGreaterEqual(i["percentage"], 0.0)
+            self.assertLessEqual(i["percentage"], 100.0)
+
+    # ---------------------------
+    # 잘못된 날짜 형식: 400
+    # ---------------------------
+    def test_invalid_date_format(self) -> None:
+        """YYYY-MM-DD 형식이 아니면 400"""
+        self.client.force_authenticate(self.admin)
+        r = self.client.get(self.base_url, {"date_from": "2025/01/01"})
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("날짜 형식", r.data["error"])
+
+    # ---------------------------
+    # 미래 날짜 포함: 400
+    # ---------------------------
+    def test_future_date_not_allowed(self) -> None:
+        """date_to가 오늘 기준 미래면 400"""
+        self.client.force_authenticate(self.admin)
+
+        today = self.today
+        date_from = date(today.year - 1, 1, 1).isoformat()
+        date_to = (today + timedelta(days=1)).isoformat()
+        r = self.client.get(self.base_url, {"date_from": date_from, "date_to": date_to})
+
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("미래 날짜는 허용되지 않습니다.", r.data["error"])
+
+    # ---------------------------
+    # 시작일 > 종료일: 400
+    # ---------------------------
+    def test_date_range_reversed(self) -> None:
+        """date_from이 date_to보다 이후면 400"""
+        self.client.force_authenticate(self.admin)
+
+        today = self.today
+        date_from = today.isoformat()
+        date_to = date(today.year - 1, 1, 1).isoformat()
+        r = self.client.get(self.base_url, {"date_from": date_from, "date_to": date_to})
+
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("시작일은 종료일보다 이후일 수 없습니다.", r.data["error"])
+
+    # ---------------------------
+    # 권한 없음: 403
+    # ---------------------------
+    def test_forbidden(self) -> None:
+        """staff 권한 없으면 → 403"""
+        self.client.force_authenticate(self.normal_user)
+        r = self.client.get(self.base_url)
+        self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
+
+    # ---------------------------
+    # 인증 없음: 401
+    # ---------------------------
+    def test_unauthorized(self) -> None:
+        """인증 없으면 → 401"""
+        r = self.client.get(self.base_url)
+        self.assertEqual(r.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/apps/users/urls/admin_urls.py
+++ b/apps/users/urls/admin_urls.py
@@ -4,7 +4,10 @@ from apps.users.views.admin_dashboard_trend_views import (
     SignupTrendsAPIView,
     WithdrawalTrendsAPIView,
 )
-from apps.users.views.admin_dashboard_views import AdminWithdrawalReasonStatsView
+from apps.users.views.admin_dashboard_views import (
+    AdminWithdrawalReasonStatsAllTimeView,
+    AdminWithdrawalReasonStatsView,
+)
 from apps.users.views.admin_users_views import (
     AdminUserListView,
     AdminUserRoleUpdateView,
@@ -50,7 +53,7 @@ urlpatterns = [
         "admin/dashboard/withdrawals/trends",
         WithdrawalTrendsAPIView.as_view(),
         name="withdrawal_trends",
-    ),
+    ),  # 회원 탈퇴 추세
     path(
         "admin/dashboard/withdrawals/stats",
         AdminWithdrawalReasonStatsView.as_view(),
@@ -61,4 +64,9 @@ urlpatterns = [
         SignupTrendsAPIView.as_view(),
         name="signup_trends",
     ),
+    path(
+        "admin/dashboard/withdrawals/reasons",
+        AdminWithdrawalReasonStatsAllTimeView.as_view(),
+        name="admin_withdrawal_reason_distribution",
+    ),  # 회원 탈퇴 사유 분포
 ]

--- a/apps/users/views/admin_dashboard_views.py
+++ b/apps/users/views/admin_dashboard_views.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from datetime import date
+from typing import Optional
+
+from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import status
@@ -10,17 +14,25 @@ from rest_framework.response import Response
 from apps.core.views import ExceptionHandledAPIView
 from apps.users.enums import Reason
 from apps.users.permissions import IsStaffRole
+from apps.users.serializers.admin_dashboard_serializers import (
+    AdminWithdrawalReasonDistributionResponseSerializer,
+    AdminWithdrawalReasonTrendResponseSerializer,
+)
 from apps.users.services.admin_dashboard_services import AdminDashboardStatsService
 
 
 class AdminWithdrawalReasonStatsView(ExceptionHandledAPIView):
+    """
+    어드민 - 회원 탈퇴 사유 추적
+    """
+
     permission_classes = [IsAuthenticated, IsStaffRole]
 
     @extend_schema(
         tags=["Admin"],
         operation_id="v1_admin_dashboard_withdrawal_reason_stats",
-        summary="대시보드 - 회원 탈퇴 사유 추적",
-        description="`reason`에 해당하는 탈퇴 사유의 최근 12개월 월별 통계를 반환",
+        summary="대시보드 - 회원 탈퇴 사유 추적(월별, 최근 12개월)",
+        description="`reason`에 해당하는 탈퇴 사유의 최근 12개월 **월별 건수**를 반환",
         parameters=[
             OpenApiParameter(
                 name="reason",
@@ -31,11 +43,7 @@ class AdminWithdrawalReasonStatsView(ExceptionHandledAPIView):
                 description="탈퇴 사유 코드",
             ),
         ],
-        responses={
-            200: OpenApiResponse(description="성공적으로 월별 통계를 반환"),
-            400: OpenApiResponse(description="요청 파라미터 오류"),
-            403: OpenApiResponse(description="관리자 권한 필요"),
-        },
+        responses={200: AdminWithdrawalReasonTrendResponseSerializer},
     )
     def get(self, request: Request) -> Response:
         reason_str = request.query_params.get("reason")
@@ -47,17 +55,73 @@ class AdminWithdrawalReasonStatsView(ExceptionHandledAPIView):
         except ValueError:
             return Response({"error": "유효하지 않은 사유입니다."}, status=status.HTTP_400_BAD_REQUEST)
 
-        # 2) 최근 12개월, 해당 사유만
-        result = AdminDashboardStatsService.get_trends(interval="month", reason=reason_enum.value)
-
-        payload = {
-            "detail": "회원탈퇴 사유 추적 조회에 성공하였습니다.",
-            "data": {
-                "interval": result.interval,
-                "from_date": result.date_from,
-                "to_date": result.date_to,
-                "total_withdrawals": result.total,
-                "items": [{"period": i.period, "count": i.count} for i in result.items],
+        payload = AdminDashboardStatsService.get_trends(interval="month", reason=reason_enum.value)
+        serializer = AdminWithdrawalReasonTrendResponseSerializer(instance=payload)
+        return Response(
+            {
+                "detail": "회원탈퇴 사유 추적 조회에 성공하였습니다.",
+                "data": serializer.data,
             },
-        }
-        return Response(payload, status=status.HTTP_200_OK)
+            status=status.HTTP_200_OK,
+        )
+
+
+class AdminWithdrawalReasonStatsAllTimeView(ExceptionHandledAPIView):
+    """
+    어드민 - 회원 탈퇴 사유 분포
+    """
+
+    permission_classes = [IsAuthenticated, IsStaffRole]
+
+    @extend_schema(
+        tags=["Admin"],
+        operation_id="v1_admin_dashboard_withdrawal_reason_distribution",
+        summary="대시보드 - 회원 탈퇴 사유 분포(전체 기간)",
+        description="모든 탈퇴 `reason`에 대해 지정 구간(없으면 전체)의 **사유별 분포/비율**을 반환",
+        parameters=[
+            OpenApiParameter(
+                name="date_from",
+                required=False,
+                type=OpenApiTypes.DATE,
+                location=OpenApiParameter.QUERY,
+                description="집계 시작일(YYYY-MM-DD). 없으면 전체 기간 시작",
+            ),
+            OpenApiParameter(
+                name="date_to",
+                required=False,
+                type=OpenApiTypes.DATE,
+                location=OpenApiParameter.QUERY,
+                description="집계 종료일(YYYY-MM-DD). 없으면 전체 기간 종료",
+            ),
+        ],
+        responses={200: AdminWithdrawalReasonDistributionResponseSerializer},
+    )
+    def get(self, request: Request) -> Response:
+        df = request.query_params.get("date_from")
+        dt = request.query_params.get("date_to")
+
+        try:
+            date_from: Optional[date] = date.fromisoformat(df) if df else None
+            date_to: Optional[date] = date.fromisoformat(dt) if dt else None
+        except ValueError:
+            return Response({"error": "날짜 형식은 YYYY-MM-DD 입니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        today = timezone.localdate()
+        if (date_from and date_from > today) or (date_to and date_to > today):
+            return Response({"error": "미래 날짜는 허용되지 않습니다."}, status=status.HTTP_400_BAD_REQUEST)
+        if date_from and date_to and date_from > date_to:
+            return Response({"error": "시작일은 종료일보다 이후일 수 없습니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        payload = AdminDashboardStatsService.get_reason_distribution_all_time(
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+        serializer = AdminWithdrawalReasonDistributionResponseSerializer(instance=payload)
+        return Response(
+            {
+                "detail": "회원 탈퇴 사유 분포 조회에 성공하였습니다.",
+                "data": serializer.data,
+            },
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 어드민 대시보드 탈퇴 사유 분포 API 생성

## 📄 상세 내용
- [x] 어드민 탈퇴 사유 분포 대시보드 서비스 생성: AdminDashboardStatsService.get_reason_distribution_all_time()
        - Withdrawal created_at 의 모든 기간 조회
        
 - [x] 어드민 탈퇴 사유 분포 대시보드 뷰 테스트 생성
 
## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
