### PR TITLE
[FE 요청 해결] 🐛 fix      : ExceptionHandledAPIView 상속 - 에러 메세지 error로 통일

### DIFF
--- a/apps/users/tests/test_password_reset.py
+++ b/apps/users/tests/test_password_reset.py
@@ -74,7 +74,7 @@ class PasswordResetIntegrationTests(IsolatedRedisTestClient):
             format="json",
         )
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertIn("detail", resp.data)
+        self.assertIn("error", resp.data)
 
     def test_token_is_one_time_consumed(self) -> None:
         token = self._issue_reset_token(email=self.user.email)
@@ -88,15 +88,14 @@ class PasswordResetIntegrationTests(IsolatedRedisTestClient):
         )
         self.assertEqual(r1.status_code, status.HTTP_200_OK)
 
-        # 2회차: 같은 토큰 재사용 → verify_and_consume에서 401 → permission에서 403
-        # DRF 설계 구조상 permission check 중일 때 예외가 발생하면 무조건 403으로 처리하기 때문에 401로 처리 불가
+        # 2회차: 같은 토큰 재사용 → verify_and_consume에서 401
         r2 = self.client.post(
             self._url_with_email(self.user.email),
             data=self._payload(new_pw="OtherPass1!!", new_pw2="OtherPass1!!"),
             format="json",
             **self._headers(token=token),  # type: ignore[arg-type]
         )
-        self.assertEqual(r2.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(r2.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_password_policy_violation_returns_400(self) -> None:
         token = self._issue_reset_token(email=self.user.email)

--- a/apps/users/views/password_reset_views.py
+++ b/apps/users/views/password_reset_views.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.core.views import ExceptionHandledAPIView
 from apps.users.enums import EmailVerificationPurpose
 from apps.users.permissions import EmailVerifiedPermission
 from apps.users.serializers.password_reset_serializers import PasswordResetSerializer
@@ -34,7 +35,7 @@ def _header(request: Request, name: str) -> Optional[str]:
         ),
     ],
 )
-class PasswordResetView(APIView):
+class PasswordResetView(ExceptionHandledAPIView):
     # 인증 비활성화
     authentication_classes: tuple[type[BaseAuthentication], ...] = ()
     permission_classes = [EmailVerifiedPermission]


### PR DESCRIPTION
## ✅ PR 요약
- ExceptionHandledAPIView 상속 - 에러 메세지 error로 통일

## 📄 상세 내용
- [x] 비밀번호 재설정 view를 ExceptionHandledAPIView 상속하도록 수정
- [x] 관련 테스트 코드 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
ExceptionHandledAPIView 상속하니 401에러가 403으로 떨어지던 부분도 해결되어서 테스트 코드 추가 수정했습니다.

## 🧪 PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
