### PR TITLE
🧪 test/docs(users): MeView 테스트 및 스웨거 명세서 수정

### DIFF
--- a/apps/users/tests/test_user_profile_api.py
+++ b/apps/users/tests/test_user_profile_api.py
@@ -56,11 +56,13 @@ class MeAPITest(APITestCase):
 
         # 검증
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["email"], self.user.email)
-        self.assertEqual(response.data["nickname"], self.user.nickname)
-        self.assertEqual(response.data["name"], self.user.name)
-        self.assertIn("profile_img_url", response.data)  # 필드 존재 확인
-        self.assertIn("created_at", response.data)
+
+        data = response.data["data"]
+        self.assertEqual(data["email"], self.user.email)
+        self.assertEqual(data["nickname"], self.user.nickname)
+        self.assertEqual(data["name"], self.user.name)
+        self.assertIn("profile_img_url", data)
+        self.assertIn("created_at", data)
 
     def test_me_unauthorized(self) -> None:
         """

--- a/apps/users/views/user_profile_views.py
+++ b/apps/users/views/user_profile_views.py
@@ -91,14 +91,26 @@ class MeView(APIView):
         tags=["Users"],
         summary="내 정보 조회",
         description="로그인한 사용자가 본인 정보를 조회한다.",
-        responses=UserProfileSerializer,
+        responses=inline_serializer(
+            name="UserProfileDetailResponse",
+            fields={
+                "detail": serializers.CharField(),
+                "data": UserProfileSerializer(),
+            },
+        ),
     )
     def get(self, request: Request) -> Response:
         """
         현재 로그인한 사용자 정보 반환
         """
         serializer = UserProfileSerializer(request.user)
-        return Response(serializer.data, status=200)
+        return Response(
+            {
+                "detail": "내 정보를 조회합니다.",
+                "data": serializer.data,
+            },
+            status=200,
+        )
 
 
 class UserProfileUpdateView(ExceptionHandledAPIView):


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 어떤 작업을 했는지 간단하게 적어주세요.
- MeView 응답 구조를 명세서 기반(detail + data)으로 수정
-MeAPITest 테스트 코드에서 새로운 구조에 맞게 KeyError 문제 해결
-스웨거(OpenAPI) 명세서도 변경된 응답 구조와 일치하도록 업데이트

## 📄 상세 내용
- [x] test_me_success에서 response.data["data"]로 접근하도록 변경
- [x] KeyError 문제 해결
- [x] 테스트가 API 명세서 기반 응답 구조와 일치하도록 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
