### PR TITLE
🐛 fix : 채팅방의 생성 및 마지막 업데이트 시각 정보 추가 (프론트엔드 요청사항)

### DIFF
--- a/apps/chat/serializers.py
+++ b/apps/chat/serializers.py
@@ -36,7 +36,7 @@ class ChatRoomSerializer(serializers.ModelSerializer[StudyGroup]):
 
     class Meta:
         model = StudyGroup
-        fields = ["uuid", "name", "last_message", "unread_message_count"]
+        fields = ["uuid", "name", "last_message", "unread_message_count", "created_at", "updated_at"]
         read_only_fields = fields
 
     def get_last_message(self, obj: Any) -> Optional[dict[str, Any]]:


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호:
- 작업 요약: 
- 프론트엔드 요청에 따라 채팅방 목록 조회 API의 응답에 created_at과 updated_at 필드를 추가하여, 프론트엔드에서 채팅방의 생성 및 마지막 업데이트 시각 정보를 활용할 수 있도록 수정

## 📄 상세 내용
- [x] apps/chat/serializers.py 수정
- ChatRoomSerializer의 Meta.fields에 created_at과 updated_at 필드를 추가
- StudyGroup 모델은 apps/core/models.py의 BaseModel을 통해 created_at과 updated_at 필드를 상속받고 있으므로, 시리얼라이저에 해당 필드들을 추가하여 노출

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
