### PR TITLE
🐛 Fix: 스터디 그룹 정보 수정 API 스웨거에 입력 필드가 없는 부분 수정

### DIFF
--- a/apps/studies/views/groups.py
+++ b/apps/studies/views/groups.py
@@ -109,6 +109,7 @@ class StudyGroupDetailUpdateView(APIView):
         tags=["StudyGroup"],
         summary="스터디 그룹 정보 수정 API",
         description=("UUID 값을 입력해주세요."),
+        request=StudyGroupCreateSerializer,
         responses={
             200: StudyGroupCreateSerializer,
         },


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 스터디 그룹 정보 수정 API 스웨거에 입력 필드가 없는 부분 수정

## 📄 상세 내용
- [ ] 스터디 그룹 정보 수정 API의 extend_schema에 request 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
