### PR TITLE
🐛 Fix : API와 실시간 웹소켓이 반환하는 메시지 데이터 구조 통일 (프론트엔드와 협의)

### DIFF
--- a/apps/chat/consumers.py
+++ b/apps/chat/consumers.py
@@ -72,24 +72,27 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
     # Receive message from WebSocket
     async def receive_json(self, content: dict[str, Any], **kwargs: Any) -> None:
         message_type = content.get("type")
-        user = self.scope["user"]
+        user = cast(User, self.scope["user"])
 
-        if message_type == "chat.message":
-            message_content = content.get("content", "").strip()  # Ensure message_content is always a string
+        if message_type == "chat.message" and user.is_authenticated:
+            message_content = content.get("content", "").strip()
+            if not message_content:
+                return
 
-            sender_id = None
-            if user.is_authenticated:
-                assert isinstance(user, User)
-                await self.create_chat_message(user, message_content)
-                sender_id = user.id
+            new_message = await self.create_chat_message(user, message_content)
 
             # Send message to room group
             await self.channel_layer.group_send(
                 self.room_group_name,
                 {
                     "type": "chat_message",
-                    "message": message_content,
-                    "sender_id": sender_id,
+                    "id": str(new_message.id),
+                    "content": new_message.content,
+                    "created_at": new_message.created_at.isoformat(),
+                    "sender": {
+                        "id": str(user.id),
+                        "nickname": user.nickname,
+                    },
                 },
             )
 
@@ -101,12 +104,12 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
             return False
         return await GroupMember.objects.filter(study_group__uuid=self.study_group_uuid, user=user).aexists()
 
-    async def create_chat_message(self, user: AbstractBaseUser, content: str) -> None:
+    async def create_chat_message(self, user: AbstractBaseUser, content: str) -> ChatMessage:
         """
         Asynchronously creates a chat message in the database.
         """
         study_group = await StudyGroup.objects.aget(uuid=self.study_group_uuid)
-        await ChatMessage.objects.acreate(
+        return await ChatMessage.objects.acreate(
             sender=cast(User, user),
             study_group=study_group,
             content=content,
@@ -114,13 +117,16 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):  # type: ignore[misc]
 
     # Receive message from room group
     async def chat_message(self, event: dict[str, Any]) -> None:
-        message = event["message"]
-        sender_id = event["sender_id"]
-
         # Send message to WebSocket
         await self.send(
             text_data=json.dumps(
-                {"type": "chat.message", "message": message, "sender_id": sender_id},
+                {
+                    "type": "chat.message",
+                    "id": event["id"],
+                    "content": event["content"],
+                    "created_at": event["created_at"],
+                    "sender": event["sender"],
+                },
                 ensure_ascii=False,
             )
         )

--- a/apps/chat/tests/test_chat_consumers.py
+++ b/apps/chat/tests/test_chat_consumers.py
@@ -98,13 +98,15 @@ class ChatConsumerTest(TransactionTestCase):
             # 5. Verify both users received the message
             response1 = await communicator1.receive_json_from(timeout=5)
             self.assertEqual(response1["type"], "chat.message")
-            self.assertEqual(response1["message"], test_message_content)
-            self.assertEqual(response1["sender_id"], user1.id)
+            self.assertEqual(response1["content"], test_message_content)
+            self.assertEqual(response1["sender"]["id"], str(user1.id))
+            self.assertEqual(response1["sender"]["nickname"], user1.nickname)
 
             response2 = await communicator2.receive_json_from(timeout=5)
             self.assertEqual(response2["type"], "chat.message")
-            self.assertEqual(response2["message"], test_message_content)
-            self.assertEqual(response2["sender_id"], user1.id)
+            self.assertEqual(response2["content"], test_message_content)
+            self.assertEqual(response2["sender"]["id"], str(user1.id))
+            self.assertEqual(response2["sender"]["nickname"], user1.nickname)
 
             # 6. Verify the message is saved in the database
             message_exists = await ChatMessage.objects.filter(


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호:
- 작업 요약:
- API와 실시간 웹소켓이 반환하는 메시지 데이터 구조가 달라 발생하는 프론트엔드의 혼란을 막고, 데이터 모델의 일관성을 확보하기 위해 채팅 관련 데이터 구조를 통일

## 📄 상세 내용
- [x] 문제 및 API 명세 확정
- 문제점: 
- 기존 코드에서는 RESTful API(메시지 목록 조회)와 WebSocket이 반환하는 메시지 객체의 구조(필드명, 중첩 구조 등)가 달라 프론트엔드에서 일관된 처리가 어려움
- 해결: 
- ChatMessageSerializer를 신뢰할 수 있는 단일 소스(Source of Truth)로 삼고, 모든 채팅 관련 API(WebSocket, 메시지 목록 API 등)가 이를 기준으로 동작하도록 명세서를 재정의

- [x] 웹소켓 로직 수정 (apps/chat/consumers.py)
- create_chat_message 메서드가 생성된 ChatMessage 객체를 반환하도록 수정
- receive_json 메서드에서 위에서 반환된 객체를 사용하고, 확정된 명세서에 맞는 데이터(id, sender 객체, content, created_at)를 구성하여 채널 그룹에 전달하도록 로직을 변경

- [x] 테스트 코드 수정 (apps/chat/tests/test_chat_consumers.py)
- 웹소켓 로직 변경으로 인해 실패하던 test_chat_message_broadcasts_to_all_users_in_group 테스트 케이스를 수정
- 새로운 데이터 구조(content, sender.id, sender.nickname)를 올바르게 검증하도록 Assertion 로직을 업데이트하여 테스트 통과

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
