### PR TITLE
💡 chore : Feature/notifications_serializers_fix

### DIFF
--- a/apps/notifications/serializers/notifications_serializers.py
+++ b/apps/notifications/serializers/notifications_serializers.py
@@ -13,7 +13,7 @@ class NotificationSerializer(ModelSerializer[Notification]):
     class Meta:
         model = Notification
         # BaseModel 에 생성 및 업데이트 자동 기록이 있으므로 exclude 사용하여 불필요한 필드 숨기는 코드
-        exclude = ("created_at", "updated_at")
+        exclude = ("updated_at",)
 
         # 클라이언트가 임의로 읽음 상태 필드를 수정할 수 없게 읽기 전용으로 설정하는 코드
         extra_kwargs = {


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #31
- 작업 요약: notifications_serializers 수정 (스웨거ui 응답값에 created_at 필드 보이게)

## 📄 상세 내용
- [ ] notifications_serializers 의 exclude 목록에서 created_at 을 지워서 스웨거ui에서 보이게 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [o] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [o] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
