### PR TITLE
🐛 Fix: 스터디 그룹 목록 조회 API 스키마에 파라미터 추가, 어드민 기능 Admin 태그로 이동

### DIFF
--- a/apps/studies/views/groups.py
+++ b/apps/studies/views/groups.py
@@ -3,7 +3,8 @@ from typing import Any, List, cast
 
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import parsers, status
 from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.request import Request
@@ -46,6 +47,21 @@ class StudyGroupListCreateView(APIView):
         operation_id="v1_studies_groups_list",
         tags=["StudyGroup"],
         summary="스터디 그룹 전체 목록 조회 API",
+        parameters=[
+            OpenApiParameter(name="page", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY),
+            OpenApiParameter(
+                name="status",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="그룹 상태 필터링: 'PENDING' = 대기중, 'ONGOING' = 진행중, 'ENDED' = 완료됨",
+            ),
+            OpenApiParameter(
+                name="search",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="검색어로 필터링",
+            ),
+        ],
         responses={
             200: StudyGroupListSerializer(many=True),
         },
@@ -135,7 +151,7 @@ class AdminStudyGroupListView(APIView):
 
     @extend_schema(
         operation_id="v1_admin_studies_groups_list",
-        tags=["StudyGroup"],
+        tags=["Admin"],
         summary="어드민용 스터디 그룹 목록 조회",
         description=(
             "관리자 전용. "
@@ -185,7 +201,7 @@ class AdminStudyGroupDetailView(APIView):
 
     @extend_schema(
         operation_id="v1_admin_studies_groups_detail",
-        tags=["StudyGroup"],
+        tags=["Admin"],
         summary="관리자 스터디 그룹 상세 조회",
         description="관리자 전용. 리더는 멤버 목록 최상단에 정렬되어 표시됩니다.",
         responses={200: AdminStudyGroupDetailSerializer},

--- a/apps/studies/views/reviews.py
+++ b/apps/studies/views/reviews.py
@@ -241,7 +241,7 @@ class GroupReviewUpdateView(generics.UpdateAPIView[Review]):
 
 @extend_schema(
     operation_id="AdminListReviews",
-    tags=["StudyGroupReview"],
+    tags=["Admin"],
     summary="어드민 리뷰 목록 조회",
     description="관리자 전용. 모든 리뷰를 조회합니다. group_uuid 쿼리 파라미터로 특정 그룹의 리뷰만 필터링 가능합니다.",
     parameters=[
@@ -284,7 +284,7 @@ class AdminReviewListView(generics.ListAPIView[Review]):
 
 @extend_schema(
     operation_id="AdminReviewDetail",
-    tags=["StudyGroupReview"],
+    tags=["Admin"],
     summary="어드민 리뷰 상세 조회",
     description="관리자 전용. 특정 리뷰의 상세 정보를 조회합니다.",
     responses={200: AdminReviewDetailSerializer},


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 스터디 그룹 목록 조회 API 스키마에 파라미터 추가, 어드민 기능 Admin 태그로 이동

## 📄 상세 내용
- [ ] 그룹 목록 조회 API의 extend_schema 에 파라미터 입력 가능하게 추가
- [ ] 어드민 기능을 Admin 태그로 이동

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
