### PR TITLE
🐛 fix(users): admin 탈퇴회원 상세조회 및 회원정보 수정 로직 개선 (status, profile_img_url)

### DIFF
--- a/apps/users/serializers/admin_users_serializer.py
+++ b/apps/users/serializers/admin_users_serializer.py
@@ -84,6 +84,7 @@ class AdminUserUpdateSerializer(serializers.ModelSerializer[UserModel]):
     phone_number = serializers.CharField(
         validators=[validate_korean_phone], required=False, help_text="휴대폰 번호 (0100000000) 저장 가능"
     )
+    profile_img = serializers.ImageField(required=False, allow_empty_file=True)
 
     class Meta:
         model = User
@@ -93,7 +94,7 @@ class AdminUserUpdateSerializer(serializers.ModelSerializer[UserModel]):
             "nickname",
             "phone_number",
             "status",
-            "profile_img_url",
+            "profile_img",
             "birthday",
         ]
         extra_kwargs = {field: {"required": False} for field in fields}

--- a/apps/users/services/admin_users_services.py
+++ b/apps/users/services/admin_users_services.py
@@ -1,5 +1,8 @@
-from typing import Any, Dict
+import logging
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
+from django.db import transaction
 from django.db.models import (
     Case,
     CharField,
@@ -12,10 +15,14 @@ from django.db.models import (
     When,
 )
 from django.shortcuts import get_object_or_404
+from rest_framework.exceptions import ValidationError
 
 from apps.core.exceptions import Conflict
+from apps.core.utils.s3_uploader import S3Uploader
 from apps.users.enums import Role, UserStatus
 from apps.users.models import User, Withdrawal
+
+logger = logging.getLogger(__name__)
 
 
 class AdminUserService:
@@ -122,6 +129,30 @@ class AdminUserService:
     def get_user(user_id: int) -> User:
         return get_object_or_404(User, id=user_id)
 
+    # ----------------------------
+    # 내부 헬퍼
+    # ----------------------------
+    @staticmethod
+    def _resolve_admin_status(value: UserStatus | str) -> bool:
+        if isinstance(value, UserStatus):
+            s = value
+        else:
+            key = str(value).strip().upper()
+            s = UserStatus[key]
+
+        if s == UserStatus.WITHDRAWAL_PENDING:
+            raise Conflict({"error": "탈퇴요청 상태는 관리자에서 직접 지정할 수 없습니다."})
+
+        return s == UserStatus.ACTIVE
+
+    @staticmethod
+    def _s3_key_from_url(url: Optional[str]) -> Optional[str]:
+        if not url:
+            return None
+        parsed = urlparse(url)
+        key = parsed.path.lstrip("/")
+        return key or None
+
     # 회원 정보 수정
     @staticmethod
     def update_user_info(user: User, update_data: Dict[str, Any]) -> User:
@@ -154,17 +185,69 @@ class AdminUserService:
 
         # --- 이전 값과 다른 새 값만 반영 ---
         update_fields: list[str] = []
-        for field, value in update_data.items():
-            if not hasattr(user, field):
-                continue
-            if getattr(user, field) != value:
+
+        # ---------- 1) status → is_active ----------
+        if "status" in update_data:
+            is_active_flag = AdminUserService._resolve_admin_status(update_data.pop("status"))
+            if user.is_active != is_active_flag:
+                user.is_active = is_active_flag
+                update_fields.append("is_active")
+
+        # ---------- 2) 프로필 이미지  ----------
+        new_profile_url: Optional[str] = None
+        new_profile_key: Optional[str] = None
+        old_profile_key: Optional[str] = AdminUserService._s3_key_from_url(user.profile_img_url)
+
+        if "profile_img" in update_data:
+            profile_img = update_data.pop("profile_img")
+
+            if not hasattr(profile_img, "read") or not hasattr(profile_img, "name"):
+                raise ValidationError({"error": "프로필 이미지는 파일로만 업로드할 수 있습니다."})
+
+            # 파일 유효성 검증
+            S3Uploader.validate_file_name(profile_img)
+            S3Uploader.validate_file_extension(profile_img)
+            content_type = getattr(profile_img, "content_type", None)
+            S3Uploader.validate_file_content_type(content_type)
+            ext = str(profile_img.name).rsplit(".", 1)[-1].lower()
+            S3Uploader.validate_file_mime(ext, content_type)
+
+            # 업로드
+            prefix = "profiles/"
+            profile_img.name = f"{user.uuid}_{profile_img.name}"
+            new_profile_url = S3Uploader.upload_file(profile_img, prefix=prefix)
+            new_profile_key = AdminUserService._s3_key_from_url(new_profile_url)
+
+            if user.profile_img_url != new_profile_url:
+                user.profile_img_url = new_profile_url
+                update_fields.append("profile_img_url")
+
+        # ---------- 3) 일반 필드 ----------
+        for field, value in list(update_data.items()):
+            if hasattr(user, field) and getattr(user, field) != value:
                 setattr(user, field, value)
                 update_fields.append(field)
 
         if not update_fields:
             return user
 
-        user.save(update_fields=update_fields)
+        # ---------- 저장  ----------
+        try:
+            with transaction.atomic():
+                user.save(update_fields=update_fields)
+                # 기존 이미지 삭제
+                if old_profile_key and new_profile_key and old_profile_key != new_profile_key:
+                    transaction.on_commit(lambda: S3Uploader.delete_file(old_profile_key))
+
+        except Exception as e:
+            # DB 저장 실패 시 신규 이미지 삭제
+            if new_profile_key:
+                try:
+                    S3Uploader.delete_file(new_profile_key)
+                except Exception:
+                    logger.warning("신규 이미지 삭제 실패: key=%s", new_profile_key, exc_info=True)
+            raise
+
         return user
 
     # 회원 권한 변경

--- a/apps/users/services/admin_withdrawal_services.py
+++ b/apps/users/services/admin_withdrawal_services.py
@@ -29,11 +29,11 @@ class AdminWithdrawalService:
 
         # '유예기간 내' 이력 우선, 없으면 최신 이력
         withdrawal = (
-            base_qs.filter(due_date__isnull=False, due_date__gte=today).order_by("-created_at").first()
+            base_qs.filter(due_date__gte=today).order_by("-created_at").first()
             or base_qs.order_by("-created_at").first()
         )
 
-        if not withdrawal or withdrawal.due_date is None:
+        if not withdrawal:
             raise ValidationError({"error": "탈퇴 이력이 없습니다."})
 
         return {

--- a/apps/users/tests/test_admin_users.py
+++ b/apps/users/tests/test_admin_users.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
-from typing import Mapping, Union
+from io import BytesIO
+from typing import Literal, Mapping, Optional, Protocol, Union
 from unittest.mock import patch
 
+import boto3
+from botocore.client import BaseClient
+from botocore.exceptions import ClientError
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import Http404
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
+from moto import mock_aws
+from PIL import Image
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
 from apps.core.exceptions import Conflict
+from apps.core.utils.s3_uploader import S3Uploader
 from apps.users.enums import Role, UserStatus
 from apps.users.models import User, Withdrawal
 from apps.users.services.admin_users_services import AdminUserService
@@ -196,6 +205,44 @@ class TestAdminUserViewAPI(AdminUserSeedMixin, APITestCase):
         self.client = APIClient()
         self.client.force_authenticate(user=self.admin)
 
+    # ========== S3 moto 헬퍼 ==========
+    class _MotoLike(Protocol):
+        def start(self) -> None: ...
+        def stop(self) -> None: ...
+
+    _moto: Optional[_MotoLike] = None
+    _s3: Optional[BaseClient] = None
+    _s3_bucket: str = "test-bucket"
+    _s3_region: Literal["ap-northeast-2"] = "ap-northeast-2"
+
+    def _start_s3_mock(self) -> None:
+        self._moto = mock_aws()
+        self._moto.start()
+
+        setattr(settings, "AWS_S3_BUCKET_NAME", self._s3_bucket)
+        setattr(settings, "AWS_S3_REGION", self._s_region if hasattr(self, "_s_region") else self._s3_region)
+        setattr(settings, "AWS_S3_ACCESS_KEY_ID", "xxx")
+        setattr(settings, "AWS_S3_SECRET_ACCESS_KEY", "yyy")
+
+        # moto S3 클라이언트
+        self._s3 = boto3.client("s3", region_name=self._s3_region)
+        self._s3.create_bucket(
+            Bucket=self._s3_bucket,
+            CreateBucketConfiguration={"LocationConstraint": self._s3_region},
+        )
+
+        # S3Uploader 바인딩
+        S3Uploader.BUCKET_NAME = self._s3_bucket
+        S3Uploader.REGION_NAME = self._s3_region
+        S3Uploader.s3_client = self._s3
+        S3Uploader.S3_BASE_URL = f"https://{self._s3_bucket}.s3.{self._s3_region}.amazonaws.com/"
+
+    def _stop_s3_mock(self) -> None:
+        if self._moto:
+            self._moto.stop()
+            self._moto = None
+            self._s3 = None
+
     # ✅ 회원 목록 조회
     def test_user_list(self) -> None:
         url = reverse("users:admin-user-list")
@@ -216,7 +263,7 @@ class TestAdminUserViewAPI(AdminUserSeedMixin, APITestCase):
 
         # 정보 수정
         payload_name = {"name": "수정된유저"}
-        response = self.client.patch(url, payload_name, format="json")
+        response = self.client.patch(url, payload_name, format="multipart")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.user.refresh_from_db()
         self.assertEqual(self.user.name, "수정된유저")
@@ -340,6 +387,72 @@ class TestAdminUserViewAPI(AdminUserSeedMixin, APITestCase):
         url = reverse("users:admin-user-detail", args=[self.user.id])
         resp = self.client.put(url, {"name": "nope"}, format="json")
         self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    # ========== (이미지) 프로필 업로드 성공 ==========
+    def test_update_profile_image_only_success(self) -> None:
+        self._start_s3_mock()
+        try:
+            url = reverse("users:admin-user-detail", args=[self.user.id])
+
+            buf = BytesIO()
+            Image.new("RGB", (1, 1), (255, 0, 0)).save(buf, format="PNG")
+            buf.seek(0)
+            img = SimpleUploadedFile("avatar.png", buf.getvalue(), content_type="image/png")
+
+            resp = self.client.patch(url, {"profile_img": img}, format="multipart")
+            self.assertEqual(resp.status_code, status.HTTP_200_OK, msg=resp.content)
+
+            body = resp.json()
+            self.assertIn("detail", body)
+            new_url = body["data"]["profile_img_url"]
+            self.assertTrue(new_url.startswith(S3Uploader.S3_BASE_URL))
+
+            new_key = new_url.replace(S3Uploader.S3_BASE_URL, "")
+            head = S3Uploader.s3_client.head_object(Bucket=S3Uploader.BUCKET_NAME, Key=new_key)
+            self.assertEqual(head["ResponseMetadata"]["HTTPStatusCode"], 200)
+        finally:
+            self._stop_s3_mock()
+
+    # ========== (이미지) 기존 이미지가 있을 때 교체 → 기존 삭제 ==========
+    def test_update_profile_image_replaces_old(self) -> None:
+        self._start_s3_mock()
+        try:
+            url = reverse("users:admin-user-detail", args=[self.user.id])
+
+            buf = BytesIO()
+            Image.new("RGB", (1, 1), (0, 255, 0)).save(buf, format="PNG")
+            buf.seek(0)
+            img_bytes = buf.getvalue()
+
+            old_key = f"profiles/{self.user.id}/old.png"
+            S3Uploader.s3_client.put_object(
+                Bucket=S3Uploader.BUCKET_NAME,
+                Key=old_key,
+                Body=img_bytes,
+                ACL="public-read",
+            )
+            self.user.profile_img_url = S3Uploader.S3_BASE_URL + old_key
+            self.user.save(update_fields=["profile_img_url"])
+
+            # 새 이미지 업로드
+            buf2 = BytesIO()
+            Image.new("RGB", (1, 1), (0, 0, 255)).save(buf2, format="PNG")
+            buf2.seek(0)
+            new_img = SimpleUploadedFile("avatar2.png", buf2.getvalue(), content_type="image/png")
+
+            resp = self.client.patch(url, {"profile_img": new_img}, format="multipart")
+            self.assertEqual(resp.status_code, status.HTTP_200_OK, msg=resp.content)
+
+            body = resp.json()
+            new_url = body["data"]["profile_img_url"]
+            self.assertTrue(new_url.startswith(S3Uploader.S3_BASE_URL))
+            new_key = new_url.replace(S3Uploader.S3_BASE_URL, "")
+
+            head_new = S3Uploader.s3_client.head_object(Bucket=S3Uploader.BUCKET_NAME, Key=new_key)
+            self.assertEqual(head_new["ResponseMetadata"]["HTTPStatusCode"], 200)
+
+        finally:
+            self._stop_s3_mock()
 
 
 # ---------------------------------------------------------------------

--- a/apps/users/views/admin_users_views.py
+++ b/apps/users/views/admin_users_views.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from django.forms import ValidationError
 from django.http import Http404
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
+from rest_framework.decorators import parser_classes
+from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -129,9 +132,12 @@ class AdminUserView(ExceptionHandledAPIView):
     @extend_schema(
         tags=["Admin"],
         summary="관리자 - 회원 정보 수정",
-        request=AdminUserUpdateSerializer,
+        request={
+            "multipart/form-data": AdminUserUpdateSerializer,
+        },
         responses={200: AdminUserUpdateResponseSerializer, 404: OpenApiTypes.OBJECT},
     )
+    @parser_classes([MultiPartParser, FormParser])
     def patch(self, request: Request, user_id: int) -> Response:
         # 회원 정보 수정
         try:


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 
- 1) 어드민 탈퇴회원 상세 조회 시 due_date 필터링 조건 수정
- 2) 어드민 회원정보 수정 시 status, profile_img 업데이트 로직 수정

## 📄 상세 내용
- [x]  어드민 탈퇴회원 상세 조회 시 due_date가 nn 필드로 nullable 처리되어 있어 null 검색 조건 삭제

- [x] 어드민 회원정보 수정 시 status 필드 업데이트 누락 수정 → is_active 필드와 매핑 처리

- [x] 어드민 회원정보 수정 시
       기존: profile_img_url(string URL)
       변경: multipart/form-data 방식으로 이미지 파일 직접 업로드 가능하도록 수정
       
- [x] 어드민 회원정보 수정의 이미지 수정 테스트 케이스 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
