### PR TITLE
🐛 fix(users): admin 탈퇴 회원 상세조회, 탈퇴 복구 엔드포인트 수정 (user_id->withdrawal_id)

### DIFF
--- a/apps/users/serializers/admin_withdrawal_serializers.py
+++ b/apps/users/serializers/admin_withdrawal_serializers.py
@@ -58,7 +58,7 @@ class WithdrawalUserDetailSerializer(serializers.ModelSerializer[User]):
 
 
 class WithdrawalInfoSerializer(serializers.ModelSerializer[Withdrawal]):
-    id = serializers.CharField(source="withdrawal_code", read_only=True)
+    id = serializers.IntegerField(read_only=True)
     created_at = serializers.DateTimeField()
     due_date = serializers.DateField()
 

--- a/apps/users/services/admin_withdrawal_services.py
+++ b/apps/users/services/admin_withdrawal_services.py
@@ -14,14 +14,20 @@ class AdminWithdrawalService:
     """관리자 탈퇴 회원 관련 서비스"""
 
     @staticmethod
-    def get_withdrawal_detail(user_id: int) -> Dict[str, Any]:
+    def get_withdrawal_detail(withdrawal_id: int) -> Dict[str, Any]:
         """
         탈퇴 회원 상세 정보 조회
         """
         try:
-            user = User.objects.get(id=user_id)
-        except User.DoesNotExist:
+            anchor: Withdrawal = Withdrawal.objects.select_related("user").get(id=withdrawal_id)
+        except Withdrawal.DoesNotExist:
+            raise NotFound("탈퇴 이력이 없습니다.")
+
+        if anchor.user_id is None or anchor.user is None:
             raise NotFound("회원 정보를 찾을 수 없습니다.")
+
+        user: User = anchor.user
+        user_id = anchor.user_id
 
         base_qs: QuerySet[Withdrawal] = Withdrawal.objects.select_related("user").filter(user_id=user_id)
 

--- a/apps/users/tests/test_admin_withdrawal.py
+++ b/apps/users/tests/test_admin_withdrawal.py
@@ -120,7 +120,10 @@ class AdminUserRestoreViewTests(APITestCase):
     user_without_withdrawal_inactive_id: ClassVar[int]
     user_with_withdrawal_active_id: ClassVar[int]
 
-    url_name = "users:admin_user_restore"
+    w_inactive_id: ClassVar[int]
+    w_active_id: ClassVar[int]
+
+    url_name = "users:admin_withdrawal_restore"
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -136,12 +139,10 @@ class AdminUserRestoreViewTests(APITestCase):
         cls.user_with_withdrawal_active_id = u3.id
 
         today = timezone.localdate()
-        Withdrawal.objects.bulk_create(
-            [
-                Withdrawal(user_id=u1.id, due_date=today),
-                Withdrawal(user_id=u3.id, due_date=today),
-            ]
-        )
+        w1 = Withdrawal.objects.create(user_id=u1.id, due_date=today)
+        w3 = Withdrawal.objects.create(user_id=u3.id, due_date=today)
+        cls.w_inactive_id = w1.id
+        cls.w_active_id = w3.id
 
     def setUp(self) -> None:
         admin = User.objects.get(pk=self.admin_id)
@@ -149,7 +150,7 @@ class AdminUserRestoreViewTests(APITestCase):
 
     def test_restore_success(self) -> None:
         """탈퇴 내역이 있는 비활성 유저 복구 → 200 & is_active=True & Withdrawal 삭제"""
-        url = reverse(self.url_name, kwargs={"user_id": self.user_with_withdrawal_inactive_id})
+        url = reverse(self.url_name, kwargs={"withdrawal_id": self.w_inactive_id})
         res = self.client.post(url)
 
         self.assertEqual(res.status_code, status.HTTP_200_OK)
@@ -158,21 +159,21 @@ class AdminUserRestoreViewTests(APITestCase):
 
     def test_user_not_found(self) -> None:
         """대상 사용자가 없을 때 → 404"""
-        url = reverse(self.url_name, kwargs={"user_id": 999999})
+        url = reverse(self.url_name, kwargs={"withdrawal_id": 999_999})
         res = self.client.post(url)
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("error", res.data)
 
     def test_withdrawal_not_found(self) -> None:
         """탈퇴 내역이 없을 때 → 404"""
-        url = reverse(self.url_name, kwargs={"user_id": self.user_without_withdrawal_inactive_id})
+        url = reverse(self.url_name, kwargs={"withdrawal_id": 123_456_789})
         res = self.client.post(url)
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("error", res.data)
 
     def test_conflict_already_active(self) -> None:
         """이미 활성화된 계정일 때(탈퇴내역은 존재) → 409"""
-        url = reverse(self.url_name, kwargs={"user_id": self.user_with_withdrawal_active_id})
+        url = reverse(self.url_name, kwargs={"withdrawal_id": self.w_active_id})
         res = self.client.post(url)
         self.assertEqual(res.status_code, status.HTTP_409_CONFLICT)
         self.assertIn("error", res.data)
@@ -232,7 +233,7 @@ class TestAdminWithdrawalDetailAPI(APITestCase):
     # ---------------------------
     def test_withdrawal_detail_success(self) -> None:
         self.client.force_authenticate(user=self.admin_user)
-        url = reverse("users:admin_withdrawal_detail", kwargs={"user_id": self.withdrawn_user.id})
+        url = reverse("users:admin_withdrawal_detail", kwargs={"withdrawal_id": self.withdrawal.id})
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.data["detail"], "탈퇴 내역 상세 조회에 성공하였습니다.")
@@ -253,9 +254,9 @@ class TestAdminWithdrawalDetailAPI(APITestCase):
     # ---------------------------
     def test_withdrawal_detail_not_found(self) -> None:
         self.client.force_authenticate(user=self.admin_user)
-        url = reverse("users:admin_withdrawal_detail", kwargs={"user_id": self.normal_active_user.id})
+        url = reverse("users:admin_withdrawal_detail", kwargs={"withdrawal_id": 999_999})
         res = self.client.get(url)
-        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("error", res.data)
         self.assertIn("탈퇴 이력이 없습니다.", res.data["error"])
 
@@ -264,7 +265,7 @@ class TestAdminWithdrawalDetailAPI(APITestCase):
     # ---------------------------
     def test_withdrawal_detail_permission_denied(self) -> None:
         self.client.force_authenticate(user=self.withdrawn_user)
-        url = reverse("users:admin_withdrawal_detail", kwargs={"user_id": self.withdrawn_user.id})
+        url = reverse("users:admin_withdrawal_detail", kwargs={"withdrawal_id": self.withdrawn_user.id})
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -274,6 +275,6 @@ class TestAdminWithdrawalDetailAPI(APITestCase):
 # ---------------------------------------------------------------------
 class AdminWithdrawalServiceTests(TestCase):
     def test_user_not_found_raises_not_found(self) -> None:
-        # 존재하지 않는 유저 ID
+        # 존재하지 않는 탈퇴 요청 ID
         with self.assertRaises(NotFound):
-            AdminWithdrawalService.get_withdrawal_detail(user_id=999999)
+            AdminWithdrawalService.get_withdrawal_detail(withdrawal_id=999_999)

--- a/apps/users/urls/admin_urls.py
+++ b/apps/users/urls/admin_urls.py
@@ -37,14 +37,14 @@ urlpatterns = [
         name="admin_withdrawal_list",
     ),
     path(
-        "admin/users/withdrawals/<int:user_id>",
+        "admin/withdrawals/<int:withdrawal_id>",
         AdminWithdrawalDetailView.as_view(),
         name="admin_withdrawal_detail",
     ),
     path(
-        "admin/users/<int:user_id>/restore",
+        "admin/<int:withdrawal_id>/restore",
         AdminUserRestoreView.as_view(),
-        name="admin_user_restore",
+        name="admin_withdrawal_restore",
     ),
     # --------------------------------------------------------
     # 어드민 대시보드

--- a/apps/users/views/admin_withdrawal_views.py
+++ b/apps/users/views/admin_withdrawal_views.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import status
+from rest_framework.exceptions import NotFound
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -124,12 +125,12 @@ class AdminUserRestoreView(ExceptionHandledAPIView):
 
     @extend_schema(
         tags=["Admin"],
-        operation_id="v1_admin_users_restore_withdrawn_user",
+        operation_id="v1_admin_restore_withdrawn_user",
         summary="관리자 탈퇴 회원 복구",
         description=("관리자/스태프가 탈퇴 처리된 회원 계정을 복구\n"),
         parameters=[
             OpenApiParameter(
-                name="user_id",
+                name="withdrawal_id",
                 type=int,
                 location=OpenApiParameter.PATH,
                 required=True,
@@ -142,17 +143,19 @@ class AdminUserRestoreView(ExceptionHandledAPIView):
             409: OpenApiResponse(description="복구 불가 상태(이미 활성 사용자 등)"),
         },
     )
-    def post(self, request: Request, user_id: int) -> Response:
+    def post(self, request: Request, withdrawal_id: int) -> Response:
         # 아래 작업을 하나의 단위로 수행(성공 시 커밋, 실패 시 롤백)
         with transaction.atomic():
             # select_for_update: 트랜잭션 종료까지 다른 트랜잭션의 UPDATE/DELETE 대기
-            user = User.objects.select_for_update().filter(pk=user_id).first()
-            if not user:
-                return Response({"error": "대상 사용자를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+            try:
+                anchor: Withdrawal = Withdrawal.objects.select_related("user").get(id=withdrawal_id)
+            except Withdrawal.DoesNotExist:
+                raise NotFound("탈퇴 내역을 찾을 수 없습니다.")
 
-            has_withdrawal = Withdrawal.objects.filter(user_id=user.id).exists()
-            if not has_withdrawal:
-                return Response({"error": "탈퇴 내역을 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+            if anchor.user_id is None or anchor.user is None:
+                raise NotFound("대상 사용자를 찾을 수 없습니다.")
+
+            user: User = anchor.user
 
             if user.is_active:
                 return Response({"error": "이미 활성화된 계정입니다."}, status=status.HTTP_409_CONFLICT)
@@ -168,15 +171,15 @@ class AdminUserRestoreView(ExceptionHandledAPIView):
 
 @extend_schema(
     tags=["Admin"],
-    operation_id="api_v1_admin_users_withdrawals_detail",
+    operation_id="api_v1_admin_withdrawals_detail",
     summary="관리자 탈퇴 회원 상세 조회",
     responses=WithdrawalDetailResponseSerializer,
 )
 class AdminWithdrawalDetailView(ExceptionHandledAPIView):
     permission_classes = [IsAuthenticated, IsStaffRole]
 
-    def get(self, request: Request, user_id: int) -> Response:
-        data = AdminWithdrawalService.get_withdrawal_detail(user_id)
+    def get(self, request: Request, withdrawal_id: int) -> Response:
+        data = AdminWithdrawalService.get_withdrawal_detail(withdrawal_id)
         serializer = WithdrawalDetailResponseSerializer(data)
         return Response(
             {"detail": "탈퇴 내역 상세 조회에 성공하였습니다.", "data": serializer.data}, status=status.HTTP_200_OK


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 
- 1) admin 탈퇴 회원 상세 조회 (user_id -> withdrawal_id ) 수정
- 2) admin 탈퇴 회원 복구 (user_id -> withdrawal_id ) 수정
- 3) admin serializer WithdrawalInfoSerializer필드 타입 수정

## 📄 상세 내용
- [x]  admin 탈퇴 회원 상세 조회 (user_id -> withdrawal_id ) 수정
       - 엔드포인트 패스 파라미터 user_id -> withdrawal_id 수정
       - 서비스 로직 및 예외 처리 로직 수정
       - 테스트 수정
       -
- [x]  admin 탈퇴 회원 복구 (user_id -> withdrawal_id ) 수정
       - 엔드포인트 패스 파라미터 user_id -> withdrawal_id 수정
       - 테스트 수정


## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

불필요한 user_id 종속 제거

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
