### PR TITLE
🐛 fix : recruitments_id 로 받는것을 recruitments_uuid로 받게 수정 #237

### DIFF
--- a/apps/recruitments/serializers/bookmark.py
+++ b/apps/recruitments/serializers/bookmark.py
@@ -4,7 +4,6 @@ from rest_framework import serializers
 
 
 class BookmarkToggleSerializer(serializers.Serializer[Any]):
-    recruitment_id = serializers.IntegerField(read_only=True)
-    user_id = serializers.IntegerField(read_only=True)
+    recruitment_uuid = serializers.UUIDField(read_only=True)
     is_bookmarked = serializers.BooleanField(read_only=True)
     message = serializers.CharField(read_only=True)

--- a/apps/recruitments/serializers/recruitments.py
+++ b/apps/recruitments/serializers/recruitments.py
@@ -97,12 +97,16 @@ class RecruitmentListSerializer(ModelSerializer[Recruitment]):
 
 
 class RecruitmentDetailSerializer(ModelSerializer[Recruitment]):
+    """REQ-RECM-006 — 스터디 구인 공고 상세조회"""
+
+    author_nickname = serializers.CharField(source="author.nickname", read_only=True)
     tags = TagSerializer(many=True, read_only=True)
-    images = RecruitmentImageSerializer(many=True, read_only=True)
     attachments = RecruitmentAttachmentSerializer(many=True, read_only=True)
+    lectures = MyRecruitmentLectureSerializer(source="study_group.lectures", many=True, read_only=True)
+
     bookmark_count = serializers.IntegerField(read_only=True)
     is_bookmarked = serializers.SerializerMethodField()
-    author = serializers.CharField(source="author.nickname", read_only=True)
+    study_group_name = serializers.CharField(source="study_group.name", read_only=True)
 
     class Meta:
         model = Recruitment
@@ -113,17 +117,20 @@ class RecruitmentDetailSerializer(ModelSerializer[Recruitment]):
             "estimated_fee",
             "expected_headcount",
             "close_at",
-            "tags",
-            "images",
-            "attachments",
+            "created_at",
             "views_count",
             "bookmark_count",
-            "author",
-            "created_at",
+            "is_closed",
             "is_bookmarked",
+            "study_group_name",
+            "lectures",
+            "tags",
+            "attachments",
+            "author_nickname",
         ]
 
     def get_is_bookmarked(self, obj: Recruitment) -> bool:
+        """현재 로그인한 사용자가 북마크했는지 여부"""
         request = self.context.get("request")
         if not request or not request.user.is_authenticated:
             return False

--- a/apps/recruitments/serializers/recruitments.py
+++ b/apps/recruitments/serializers/recruitments.py
@@ -58,6 +58,7 @@ class MyRecruitmentLectureSerializer(serializers.ModelSerializer[CrawledLecture]
 class RecruitmentListSerializer(ModelSerializer[Recruitment]):
     tags = TagSerializer(many=True, read_only=True)
     lectures = MyRecruitmentLectureSerializer(source="study_group.lectures", many=True, read_only=True)
+    study_group_name = serializers.CharField(source="study_group.name", read_only=True)
     bookmark_count = serializers.IntegerField(read_only=True)
     is_bookmarked = serializers.SerializerMethodField()
     thumbnail_img_url = serializers.SerializerMethodField()
@@ -70,6 +71,7 @@ class RecruitmentListSerializer(ModelSerializer[Recruitment]):
             "thumbnail_img_url",
             "expected_headcount",
             "lectures",
+            "study_group_name",
             "tags",
             "close_at",
             "views_count",

--- a/apps/recruitments/serializers/recruitments.py
+++ b/apps/recruitments/serializers/recruitments.py
@@ -13,6 +13,7 @@ from apps.recruitments.models import (
     RecruitmentImage,
     Tag,
 )
+from apps.studies.models import StudyGroup
 from apps.users.models import User
 
 # Tag
@@ -104,7 +105,6 @@ class RecruitmentDetailSerializer(ModelSerializer[Recruitment]):
     class Meta:
         model = Recruitment
         fields = [
-            "id",
             "uuid",
             "title",
             "content",
@@ -136,6 +136,9 @@ class RecruitmentCreateUpdateSerializer(ModelSerializer[Recruitment]):
         child=serializers.CharField(max_length=20),
         required=False,
         allow_empty=True,
+    )
+    study_group = serializers.SlugRelatedField(
+        slug_field="uuid", queryset=StudyGroup.objects.all(), required=False, allow_null=True
     )
 
     class Meta:

--- a/apps/recruitments/tests/test_bookmark_api.py
+++ b/apps/recruitments/tests/test_bookmark_api.py
@@ -49,7 +49,7 @@ class RecruitmentBookmarkAPITestCase(APITestCase):
         )
 
         # 북마크 관련 URL
-        self.toggle_url = reverse("recruitments:bookmark-toggle", kwargs={"recruitment_id": self.recruitment.id})
+        self.toggle_url = reverse("recruitments:bookmark-toggle", kwargs={"recruitment_uuid": self.recruitment.uuid})
         self.list_url = reverse("recruitments:bookmark-list")
 
     def test_010_toggle_bookmark_add(self) -> None:

--- a/apps/recruitments/tests/test_recruitment_tag_apis.py
+++ b/apps/recruitments/tests/test_recruitment_tag_apis.py
@@ -42,7 +42,7 @@ class RecruitmentTagAPITestCase(APITestCase):
         )
         self.tag_search_create_url = reverse("recruitments:tags-search-create")
         self.tag_add_for_recruitment_url = reverse(
-            "recruitments:tags-search-add", kwargs={"recruitment_id": self.recruitment.id}
+            "recruitments:tags-search-add", kwargs={"recruitment_uuid": self.recruitment.uuid}
         )
 
     def test_002_tag_search(self) -> None:

--- a/apps/recruitments/tests/test_recruitments_api.py
+++ b/apps/recruitments/tests/test_recruitments_api.py
@@ -94,7 +94,7 @@ class RecruitmentAPITestCase(APITestCase):
             expected_headcount=4,
             close_at="2025-12-31T23:59:00Z",
         )
-        url = reverse("recruitments:detail", kwargs={"recruitment_id": recruitment.id})
+        url = reverse("recruitments:detail", kwargs={"recruitment_uuid": recruitment.uuid})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["title"], recruitment.title)
@@ -111,7 +111,7 @@ class RecruitmentAPITestCase(APITestCase):
             expected_headcount=2,
             close_at="2025-11-30T23:59:00Z",
         )
-        url = reverse("recruitments:detail", kwargs={"recruitment_id": recruitment.id})
+        url = reverse("recruitments:detail", kwargs={"recruitment_uuid": recruitment.uuid})
         data = {
             "title": "수정된 제목",
             "content": "수정된 본문",
@@ -136,7 +136,7 @@ class RecruitmentAPITestCase(APITestCase):
             expected_headcount=2,
             close_at="2025-12-01T23:59:00Z",
         )
-        url = reverse("recruitments:detail", kwargs={"recruitment_id": recruitment.id})
+        url = reverse("recruitments:detail", kwargs={"recruitment_uuid": recruitment.uuid})
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Recruitment.objects.filter(pk=recruitment.id).exists())

--- a/apps/recruitments/tests/test_tags_api.py
+++ b/apps/recruitments/tests/test_tags_api.py
@@ -1,0 +1,90 @@
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.recruitments.models import Recruitment, Tag
+from apps.studies.models import StudyGroup
+
+User = get_user_model()
+
+
+class RecruitmentTagAPITestCase(APITestCase):
+    """REQ-RECM-002, 008"""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            email="tagtester@example.com",
+            password="password123",
+            name="태그유저",
+            nickname="user3",
+            phone_number="01099998888",
+            gender="M",
+            birthday="1997-03-03",
+        )
+
+        self.study_group = StudyGroup.objects.create(
+            name="Django 입문 스터디",
+            start_at=timezone.now() + timedelta(days=1),
+            end_at=timezone.now() + timedelta(days=30),
+        )
+
+        self.recruitment = Recruitment.objects.create(
+            author=self.user,
+            study_group=self.study_group,
+            title="태그용 공고",
+            content="내용",
+            estimated_fee=15000,
+            expected_headcount=3,
+        )
+        self.tag_search_create_url = reverse("recruitments:tags-search-create")
+        self.tag_add_for_recruitment_url = reverse(
+            "recruitments:tags-search-add", kwargs={"recruitment_id": self.recruitment.id}
+        )
+
+    def test_002_tag_search(self) -> None:
+        """REQ-RECM-002 — 태그 검색"""
+        Tag.objects.create(name="Python")
+        Tag.objects.create(name="Django")
+
+        response = self.client.get(self.tag_search_create_url, {"keyword": "Py"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+        self.assertGreaterEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["name"], "Python")
+
+    def test_002_tag_create(self) -> None:
+        """REQ-RECM-002 — 태그 신규 등록"""
+        data = {"tags": ["AI", "DeepLearning"]}
+        response = self.client.post(self.tag_search_create_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn("created_tags", response.data)
+        self.assertTrue(Tag.objects.filter(name="AI").exists())
+        self.assertTrue(Tag.objects.filter(name="DeepLearning").exists())
+
+    def test_008_tag_add_for_recruitment(self) -> None:
+        """REQ-RECM-008 — 특정 공고에 태그 추가"""
+        Tag.objects.create(name="Backend")
+        Tag.objects.create(name="Python")
+
+        data = {"tags": ["Backend", "Python"]}
+        response = self.client.post(self.tag_add_for_recruitment_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn("added_tags", response.data)
+        self.assertEqual(set(response.data["added_tags"]), {"Backend", "Python"})
+        self.assertEqual(response.data["recruitment_id"], self.recruitment.id)
+
+    def test_008_tag_add_exceeds_limit(self) -> None:
+        """REQ-RECM-008 — 공고당 태그 5개 초과 시 400 반환"""
+        # 미리 5개 태그를 연결
+        for i in range(5):
+            tag = Tag.objects.create(name=f"Tag{i}")
+            self.recruitment.tags.add(tag)
+
+        data = {"tags": ["NewTag"]}
+        response = self.client.post(self.tag_add_for_recruitment_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.data)

--- a/apps/recruitments/tests/test_tags_api.py
+++ b/apps/recruitments/tests/test_tags_api.py
@@ -42,8 +42,10 @@ class RecruitmentTagAPITestCase(APITestCase):
         )
         self.tag_search_create_url = reverse("recruitments:tags-search-create")
         self.tag_add_for_recruitment_url = reverse(
-            "recruitments:tags-search-add", kwargs={"recruitment_id": self.recruitment.id}
+            "recruitments:tags-search-add", kwargs={"recruitment_uuid": self.recruitment.uuid}
         )
+
+        self.client.force_authenticate(user=self.user)
 
     def test_002_tag_search(self) -> None:
         """REQ-RECM-002 — 태그 검색"""

--- a/apps/recruitments/urls/bookmark.py
+++ b/apps/recruitments/urls/bookmark.py
@@ -7,7 +7,7 @@ from apps.recruitments.views.bookmark import (
 
 urlpatterns = [
     path(
-        "/bookmarks/<int:recruitment_uuid>", RecruitmentBookmarkToggleAPIView.as_view(), name="bookmark-toggle"
+        "/bookmarks/<uuid:recruitment_uuid>", RecruitmentBookmarkToggleAPIView.as_view(), name="bookmark-toggle"
     ),  # REQ-RECM-010
     path("/bookmarks", RecruitmentBookmarkedListAPIView.as_view(), name="bookmark-list"),  # REQ-RECM-011
 ]

--- a/apps/recruitments/urls/bookmark.py
+++ b/apps/recruitments/urls/bookmark.py
@@ -7,7 +7,7 @@ from apps.recruitments.views.bookmark import (
 
 urlpatterns = [
     path(
-        "/bookmarks/<int:recruitment_id>", RecruitmentBookmarkToggleAPIView.as_view(), name="bookmark-toggle"
+        "/bookmarks/<int:recruitment_uuid>", RecruitmentBookmarkToggleAPIView.as_view(), name="bookmark-toggle"
     ),  # REQ-RECM-010
     path("/bookmarks", RecruitmentBookmarkedListAPIView.as_view(), name="bookmark-list"),  # REQ-RECM-011
 ]

--- a/apps/recruitments/urls/recruitment_tags.py
+++ b/apps/recruitments/urls/recruitment_tags.py
@@ -8,7 +8,7 @@ from apps.recruitments.views.recruitment_tag_views import (
 urlpatterns = [
     path("/recruitments-tags", RecruitmentTagSearchCreateAPIView.as_view(), name="tags-search-create"),  # REQ-RECM-002
     path(
-        "/recruitments-tags/<int:recruitment_id>",
+        "/recruitments-tags/<int:recruitment_uuid>",
         RecruitmentTagSearchAddForRecruitmentAPIView.as_view(),
         name="tags-search-add",
     ),  # REQ-RECM-008

--- a/apps/recruitments/urls/recruitment_tags.py
+++ b/apps/recruitments/urls/recruitment_tags.py
@@ -8,7 +8,7 @@ from apps.recruitments.views.recruitment_tag_views import (
 urlpatterns = [
     path("/recruitments-tags", RecruitmentTagSearchCreateAPIView.as_view(), name="tags-search-create"),  # REQ-RECM-002
     path(
-        "/recruitments-tags/<int:recruitment_uuid>",
+        "/recruitments-tags/<uuid:recruitment_uuid>",
         RecruitmentTagSearchAddForRecruitmentAPIView.as_view(),
         name="tags-search-add",
     ),  # REQ-RECM-008

--- a/apps/recruitments/urls/recruitments.py
+++ b/apps/recruitments/urls/recruitments.py
@@ -9,7 +9,7 @@ from apps.recruitments.views.recruitments import (
 urlpatterns = [
     path("", RecruitmentListCreateAPIView.as_view(), name="list-create"),  # REQ-RECM-001,003
     path(
-        "/<int:recruitment_uuid>", RecruitmentDetailUpdateDeleteAPIView.as_view(), name="detail"
+        "/<uuid:recruitment_uuid>", RecruitmentDetailUpdateDeleteAPIView.as_view(), name="detail"
     ),  # REQ-RECM-006,007,009
     path("/mine", RecruitmentUserListAPIView.as_view(), name="user-list"),  # REQ-RECM-005
 ]

--- a/apps/recruitments/urls/recruitments.py
+++ b/apps/recruitments/urls/recruitments.py
@@ -9,7 +9,7 @@ from apps.recruitments.views.recruitments import (
 urlpatterns = [
     path("", RecruitmentListCreateAPIView.as_view(), name="list-create"),  # REQ-RECM-001,003
     path(
-        "/<int:recruitment_id>", RecruitmentDetailUpdateDeleteAPIView.as_view(), name="detail"
+        "/<int:recruitment_uuid>", RecruitmentDetailUpdateDeleteAPIView.as_view(), name="detail"
     ),  # REQ-RECM-006,007,009
     path("/mine", RecruitmentUserListAPIView.as_view(), name="user-list"),  # REQ-RECM-005
 ]

--- a/apps/recruitments/views/bookmark.py
+++ b/apps/recruitments/views/bookmark.py
@@ -29,12 +29,11 @@ class RecruitmentBookmarkToggleAPIView(generics.GenericAPIView):  # type: ignore
     lookup_field = "uuid"
     lookup_url_kwarg = "recruitment_uuid"
 
-    def post(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
+    def post(self, request: Request, recruitment_uuid: str, *args: Any, **kwargs: Any) -> Response:
         """POST /api/v1/recruitments/bookmarks/{recruitment_uuid}/ — 북마크 토글"""
-        try:
-            recruitment = Recruitment.objects.get(pk=recruitment_id)
-        except Recruitment.DoesNotExist:
-            return Response({"error": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+        from django.shortcuts import get_object_or_404
+
+        recruitment = get_object_or_404(Recruitment, uuid=recruitment_uuid)
 
         user: User = cast(User, request.user)
         is_bookmarked: bool = toggle_bookmark(recruitment, user)

--- a/apps/recruitments/views/bookmark.py
+++ b/apps/recruitments/views/bookmark.py
@@ -26,21 +26,20 @@ class RecruitmentBookmarkToggleAPIView(generics.GenericAPIView):  # type: ignore
 
     permission_classes = [IsAuthenticated]
     serializer_class = BookmarkToggleSerializer
+    lookup_field = "uuid"
+    lookup_url_kwarg = "recruitment_uuid"
 
     def post(self, request: Request, recruitment_id: int, *args: Any, **kwargs: Any) -> Response:
-        """POST /api/v1/recruitments/{id}/bookmark — 북마크 추가 or 삭제"""
+        """POST /api/v1/recruitments/bookmarks/{recruitment_uuid}/ — 북마크 토글"""
         try:
             recruitment = Recruitment.objects.get(pk=recruitment_id)
         except Recruitment.DoesNotExist:
             return Response({"error": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
 
-        # mypy가 AnonymousUser 가능성을 오인하므로 타입 확정
         user: User = cast(User, request.user)
-
         is_bookmarked: bool = toggle_bookmark(recruitment, user)
         data = {
-            "recruitment_id": recruitment.id,
-            "user_id": user.id,
+            "recruitment_uuid": str(recruitment.uuid),
             "is_bookmarked": is_bookmarked,
             "message": "북마크가 추가되었습니다." if is_bookmarked else "북마크가 해제되었습니다.",
         }
@@ -50,9 +49,7 @@ class RecruitmentBookmarkToggleAPIView(generics.GenericAPIView):  # type: ignore
 
 @extend_schema(tags=["recruitments"], summary="북마크한 스터디 구인 공고 목록 조회")
 class RecruitmentBookmarkedListAPIView(generics.ListAPIView):  # type: ignore[type-arg]
-    """
-    REQ-RECM-011 — 북마크 목록 조회
-    """
+    """REQ-RECM-011 — 북마크 목록 조회"""
 
     permission_classes = [IsAuthenticated]
     serializer_class = RecruitmentListSerializer

--- a/apps/recruitments/views/recruitment_tag_views.py
+++ b/apps/recruitments/views/recruitment_tag_views.py
@@ -117,8 +117,10 @@ class RecruitmentTagSearchAddForRecruitmentAPIView(generics.GenericAPIView[Any])
     serializer_class = RecruitmentTagAddSerializer
 
     def get_object(self) -> Recruitment:
-        """recruitment_id로 해당 공고를 조회"""
-        return Recruitment.objects.get(pk=self.kwargs["recruitment_id"])
+        """recruitment_uuid로 해당 공고를 조회"""
+        from django.shortcuts import get_object_or_404
+
+        return get_object_or_404(Recruitment, uuid=self.kwargs["recruitment_uuid"])
 
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         keyword: str = request.query_params.get("keyword", "")

--- a/apps/recruitments/views/recruitments.py
+++ b/apps/recruitments/views/recruitments.py
@@ -153,7 +153,7 @@ class RecruitmentDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView
         if self.request.method in ("PUT", "PATCH"):
             return RecruitmentCreateUpdateSerializer
         elif self.request.method == "GET":
-            return RecruitmentListSerializer
+            return RecruitmentDetailSerializer
         return RecruitmentDetailSerializer
 
     def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/apps/recruitments/views/recruitments.py
+++ b/apps/recruitments/views/recruitments.py
@@ -58,6 +58,7 @@ class RecruitmentListCreateAPIView(generics.GenericAPIView):  # type: ignore[typ
             Recruitment.objects.filter(is_closed=False)
             .annotate(bookmark_count=Count("bookmarks"))
             .prefetch_related("tags", "images", "attachments")
+            .order_by("-created_at")
         )
         keyword = self.request.query_params.get("keyword")
         tag = self.request.query_params.get("tag")
@@ -139,6 +140,7 @@ class RecruitmentUserListAPIView(generics.ListAPIView):  # type: ignore[type-arg
 class RecruitmentDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView):  # type: ignore[type-arg]
     """REQ-RECM-006, 007, 009 — 스터디 구인 공고 상세, 수정, 삭제"""
 
+    lookup_field = "uuid"
     lookup_url_kwarg = "recruitment_uuid"
     queryset = (
         Recruitment.objects.all()
@@ -164,182 +166,6 @@ class RecruitmentDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView
         serializer = RecruitmentCreateUpdateSerializer(instance, data=request.data, partial=False)
         serializer.is_valid(raise_exception=True)
         updated_instance = update_recruitment(instance, serializer.validated_data)
-        from typing import Any, cast
-
-        from django.contrib.auth.models import AbstractUser
-        from django.db.models import Count, QuerySet
-        from drf_spectacular.utils import OpenApiResponse, extend_schema
-        from rest_framework import generics, status
-        from rest_framework.permissions import (
-            IsAuthenticated,
-            IsAuthenticatedOrReadOnly,
-        )
-        from rest_framework.request import Request
-        from rest_framework.response import Response
-        from rest_framework.serializers import BaseSerializer, Serializer
-
-        from apps.recruitments.models import Recruitment
-        from apps.recruitments.serializers.recruitments import (
-            RecruitmentCreateUpdateSerializer,
-            RecruitmentDetailSerializer,
-            RecruitmentListSerializer,
-        )
-        from apps.recruitments.services.pagination import RecruitmentPagination
-        from apps.recruitments.services.recruitments import (
-            create_recruitment,
-            get_recommended_recruitments_for_user,
-            increase_views,
-            update_recruitment,
-        )
-        from apps.users.models import User
-
-        @extend_schema(
-            tags=["recruitments"],
-            summary="스터디 구인 공고 작성 및 목록 조회",
-            description=(
-                "로그인한 사용자는 새로운 스터디 구인 공고를 등록할 수 있습니다.\n\n"
-                "- 마크다운 형식 본문(content)\n"
-                "- 이미지 최대 5개 (5MB 이하)\n"
-                "- 첨부파일 최대 3개 (5MB 이하)\n"
-                "- 공고당 최대 5개의 사용자 정의 태그 등록 가능"
-            ),
-            request={"multipart/form-data": RecruitmentCreateUpdateSerializer},
-            responses={
-                200: OpenApiResponse(response=RecruitmentListSerializer, description="스터디 구인 공고 목록 조회 성공"),
-                201: OpenApiResponse(response=RecruitmentDetailSerializer, description="스터디 구인 공고 등록 성공"),
-                400: OpenApiResponse(description="유효하지 않은 요청 데이터"),
-                401: OpenApiResponse(description="인증되지 않은 사용자"),
-            },
-        )
-        class RecruitmentListCreateAPIView(generics.GenericAPIView):  # type: ignore[type-arg]
-            """REQ-RECM-001, REQ-RECM-003 — 스터디 구인공고 목록 조회 및 생성"""
-
-            permission_classes = [IsAuthenticatedOrReadOnly]
-            serializer_class: type[RecruitmentListSerializer] = RecruitmentListSerializer
-            pagination_class = RecruitmentPagination
-
-            def get_queryset(self) -> QuerySet[Recruitment]:
-                qs = (
-                    Recruitment.objects.filter(is_closed=False)
-                    .annotate(bookmark_count=Count("bookmarks"))
-                    .prefetch_related("tags", "images", "attachments")
-                )
-                keyword = self.request.query_params.get("keyword")
-                tag = self.request.query_params.get("tag")
-                ordering = self.request.query_params.get("ordering", "latest")
-
-                if keyword:
-                    qs = qs.filter(title__icontains=keyword)
-                if tag:
-                    qs = qs.filter(tags__name__icontains=tag)
-
-                if ordering == "views":
-                    qs = qs.order_by("-views_count")
-                elif ordering == "bookmarks":
-                    qs = qs.order_by("-bookmark_count")
-                else:
-                    qs = qs.order_by("-created_at")
-
-                return qs
-
-            def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-                queryset = self.get_queryset()
-                page = self.paginate_queryset(queryset)
-                serializer = RecruitmentListSerializer(page, many=True, context={"request": request})
-                paginated = self.get_paginated_response(serializer.data).data
-
-                if request.user.is_authenticated:
-                    user = cast(User, request.user)  # type: ignore[redundant-cast]
-                    recommended_qs = get_recommended_recruitments_for_user(user, limit=3)
-                    recommended_serializer = RecruitmentListSerializer(
-                        recommended_qs, many=True, context={"request": request}
-                    )
-                    paginated["recommended_recruitments"] = recommended_serializer.data
-                else:
-                    paginated["recommended_recruitments"] = []
-
-                return Response(paginated)
-
-            def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-                serializer = RecruitmentCreateUpdateSerializer(data=request.data)
-                serializer.is_valid(raise_exception=True)
-                user = cast(User, request.user)
-                recruitment = create_recruitment(user, serializer.validated_data)
-                detail_serializer = RecruitmentDetailSerializer(recruitment, context={"request": request})
-                return Response(detail_serializer.data, status=status.HTTP_201_CREATED)
-
-        @extend_schema(tags=["recruitments"], summary="내가 작성한 스터디 구인 공고 목록 조회")
-        class RecruitmentUserListAPIView(generics.ListAPIView):  # type: ignore[type-arg]
-            """REQ-RECM-005 — 사용자별 스터디 구인 공고 목록 조회"""
-
-            serializer_class = RecruitmentListSerializer
-            permission_classes = [IsAuthenticatedOrReadOnly]
-            pagination_class = RecruitmentPagination
-
-            def get_queryset(self) -> QuerySet[Recruitment]:
-                qs = (
-                    Recruitment.objects.filter(author_id=self.request.user.id)
-                    .annotate(bookmark_count=Count("bookmarks"))
-                    .prefetch_related("tags", "images", "study_group__lectures")
-                )
-
-                status_param = self.request.query_params.get("status")
-                ordering = self.request.query_params.get("ordering", "latest")
-
-                if status_param == "open":
-                    qs = qs.filter(is_closed=False)
-                elif status_param == "closed":
-                    qs = qs.filter(is_closed=True)
-
-                if ordering == "views":
-                    qs = qs.order_by("-views_count")
-                elif ordering == "bookmarks":
-                    qs = qs.order_by("-bookmark_count")
-                else:
-                    qs = qs.order_by("-created_at")
-
-                return qs
-
-        @extend_schema(tags=["recruitments"], summary="스터디 구인 공고 상세 조회 / 수정 / 삭제")
-        class RecruitmentDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView):  # type: ignore[type-arg]
-            """REQ-RECM-006, 007, 009 — 스터디 구인 공고 상세, 수정, 삭제"""
-
-            lookup_url_kwarg = "recruitment_uuid"
-            queryset = (
-                Recruitment.objects.all()
-                .annotate(bookmark_count=Count("bookmarks"))
-                .prefetch_related("tags", "images", "attachments")
-            )
-            permission_classes = [IsAuthenticatedOrReadOnly]
-
-            def get_serializer_class(self) -> type[Serializer[Any]]:
-                if self.request.method in ("PUT", "PATCH"):
-                    return RecruitmentCreateUpdateSerializer
-                return RecruitmentDetailSerializer
-
-            def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-                instance = self.get_object()
-                increase_views(instance)
-                serializer = self.get_serializer(instance, context={"request": request})
-                return Response(serializer.data)
-
-            def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-                """PUT/PATCH 시에는 create/update serializer로 검증 → detail serializer로 응답"""
-                instance = self.get_object()
-                serializer = RecruitmentCreateUpdateSerializer(instance, data=request.data, partial=False)
-                serializer.is_valid(raise_exception=True)
-                updated_instance = update_recruitment(instance, serializer.validated_data)
-
-                response_serializer = RecruitmentDetailSerializer(updated_instance, context={"request": request})
-                return Response(response_serializer.data, status=status.HTTP_200_OK)
-
-            def perform_update(self, serializer: BaseSerializer[Any]) -> None:
-                recruitment = self.get_object()
-                update_recruitment(recruitment, serializer.validated_data)
 
         response_serializer = RecruitmentDetailSerializer(updated_instance, context={"request": request})
         return Response(response_serializer.data, status=status.HTTP_200_OK)
-
-    def perform_update(self, serializer: BaseSerializer[Any]) -> None:
-        recruitment = self.get_object()
-        update_recruitment(recruitment, serializer.validated_data)

--- a/apps/recruitments/views/recruitments.py
+++ b/apps/recruitments/views/recruitments.py
@@ -152,6 +152,8 @@ class RecruitmentDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView
     def get_serializer_class(self) -> type[Serializer[Any]]:
         if self.request.method in ("PUT", "PATCH"):
             return RecruitmentCreateUpdateSerializer
+        elif self.request.method == "GET":
+            return RecruitmentListSerializer
         return RecruitmentDetailSerializer
 
     def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/apps/recruitments/views/recruitments.py
+++ b/apps/recruitments/views/recruitments.py
@@ -139,7 +139,7 @@ class RecruitmentUserListAPIView(generics.ListAPIView):  # type: ignore[type-arg
 class RecruitmentDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView):  # type: ignore[type-arg]
     """REQ-RECM-006, 007, 009 — 스터디 구인 공고 상세, 수정, 삭제"""
 
-    lookup_url_kwarg = "recruitment_id"
+    lookup_url_kwarg = "recruitment_uuid"
     queryset = (
         Recruitment.objects.all()
         .annotate(bookmark_count=Count("bookmarks"))
@@ -164,6 +164,178 @@ class RecruitmentDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView
         serializer = RecruitmentCreateUpdateSerializer(instance, data=request.data, partial=False)
         serializer.is_valid(raise_exception=True)
         updated_instance = update_recruitment(instance, serializer.validated_data)
+        from typing import Any, cast
+
+        from django.contrib.auth.models import AbstractUser
+        from django.db.models import Count, QuerySet
+        from drf_spectacular.utils import OpenApiResponse, extend_schema
+        from rest_framework import generics, status
+        from rest_framework.permissions import (
+            IsAuthenticated,
+            IsAuthenticatedOrReadOnly,
+        )
+        from rest_framework.request import Request
+        from rest_framework.response import Response
+        from rest_framework.serializers import BaseSerializer, Serializer
+
+        from apps.recruitments.models import Recruitment
+        from apps.recruitments.serializers.recruitments import (
+            RecruitmentCreateUpdateSerializer,
+            RecruitmentDetailSerializer,
+            RecruitmentListSerializer,
+        )
+        from apps.recruitments.services.pagination import RecruitmentPagination
+        from apps.recruitments.services.recruitments import (
+            create_recruitment,
+            get_recommended_recruitments_for_user,
+            increase_views,
+            update_recruitment,
+        )
+        from apps.users.models import User
+
+        @extend_schema(
+            tags=["recruitments"],
+            summary="스터디 구인 공고 작성 및 목록 조회",
+            description=(
+                "로그인한 사용자는 새로운 스터디 구인 공고를 등록할 수 있습니다.\n\n"
+                "- 마크다운 형식 본문(content)\n"
+                "- 이미지 최대 5개 (5MB 이하)\n"
+                "- 첨부파일 최대 3개 (5MB 이하)\n"
+                "- 공고당 최대 5개의 사용자 정의 태그 등록 가능"
+            ),
+            request={"multipart/form-data": RecruitmentCreateUpdateSerializer},
+            responses={
+                200: OpenApiResponse(response=RecruitmentListSerializer, description="스터디 구인 공고 목록 조회 성공"),
+                201: OpenApiResponse(response=RecruitmentDetailSerializer, description="스터디 구인 공고 등록 성공"),
+                400: OpenApiResponse(description="유효하지 않은 요청 데이터"),
+                401: OpenApiResponse(description="인증되지 않은 사용자"),
+            },
+        )
+        class RecruitmentListCreateAPIView(generics.GenericAPIView):  # type: ignore[type-arg]
+            """REQ-RECM-001, REQ-RECM-003 — 스터디 구인공고 목록 조회 및 생성"""
+
+            permission_classes = [IsAuthenticatedOrReadOnly]
+            serializer_class: type[RecruitmentListSerializer] = RecruitmentListSerializer
+            pagination_class = RecruitmentPagination
+
+            def get_queryset(self) -> QuerySet[Recruitment]:
+                qs = (
+                    Recruitment.objects.filter(is_closed=False)
+                    .annotate(bookmark_count=Count("bookmarks"))
+                    .prefetch_related("tags", "images", "attachments")
+                )
+                keyword = self.request.query_params.get("keyword")
+                tag = self.request.query_params.get("tag")
+                ordering = self.request.query_params.get("ordering", "latest")
+
+                if keyword:
+                    qs = qs.filter(title__icontains=keyword)
+                if tag:
+                    qs = qs.filter(tags__name__icontains=tag)
+
+                if ordering == "views":
+                    qs = qs.order_by("-views_count")
+                elif ordering == "bookmarks":
+                    qs = qs.order_by("-bookmark_count")
+                else:
+                    qs = qs.order_by("-created_at")
+
+                return qs
+
+            def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+                queryset = self.get_queryset()
+                page = self.paginate_queryset(queryset)
+                serializer = RecruitmentListSerializer(page, many=True, context={"request": request})
+                paginated = self.get_paginated_response(serializer.data).data
+
+                if request.user.is_authenticated:
+                    user = cast(User, request.user)  # type: ignore[redundant-cast]
+                    recommended_qs = get_recommended_recruitments_for_user(user, limit=3)
+                    recommended_serializer = RecruitmentListSerializer(
+                        recommended_qs, many=True, context={"request": request}
+                    )
+                    paginated["recommended_recruitments"] = recommended_serializer.data
+                else:
+                    paginated["recommended_recruitments"] = []
+
+                return Response(paginated)
+
+            def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+                serializer = RecruitmentCreateUpdateSerializer(data=request.data)
+                serializer.is_valid(raise_exception=True)
+                user = cast(User, request.user)
+                recruitment = create_recruitment(user, serializer.validated_data)
+                detail_serializer = RecruitmentDetailSerializer(recruitment, context={"request": request})
+                return Response(detail_serializer.data, status=status.HTTP_201_CREATED)
+
+        @extend_schema(tags=["recruitments"], summary="내가 작성한 스터디 구인 공고 목록 조회")
+        class RecruitmentUserListAPIView(generics.ListAPIView):  # type: ignore[type-arg]
+            """REQ-RECM-005 — 사용자별 스터디 구인 공고 목록 조회"""
+
+            serializer_class = RecruitmentListSerializer
+            permission_classes = [IsAuthenticatedOrReadOnly]
+            pagination_class = RecruitmentPagination
+
+            def get_queryset(self) -> QuerySet[Recruitment]:
+                qs = (
+                    Recruitment.objects.filter(author_id=self.request.user.id)
+                    .annotate(bookmark_count=Count("bookmarks"))
+                    .prefetch_related("tags", "images", "study_group__lectures")
+                )
+
+                status_param = self.request.query_params.get("status")
+                ordering = self.request.query_params.get("ordering", "latest")
+
+                if status_param == "open":
+                    qs = qs.filter(is_closed=False)
+                elif status_param == "closed":
+                    qs = qs.filter(is_closed=True)
+
+                if ordering == "views":
+                    qs = qs.order_by("-views_count")
+                elif ordering == "bookmarks":
+                    qs = qs.order_by("-bookmark_count")
+                else:
+                    qs = qs.order_by("-created_at")
+
+                return qs
+
+        @extend_schema(tags=["recruitments"], summary="스터디 구인 공고 상세 조회 / 수정 / 삭제")
+        class RecruitmentDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView):  # type: ignore[type-arg]
+            """REQ-RECM-006, 007, 009 — 스터디 구인 공고 상세, 수정, 삭제"""
+
+            lookup_url_kwarg = "recruitment_uuid"
+            queryset = (
+                Recruitment.objects.all()
+                .annotate(bookmark_count=Count("bookmarks"))
+                .prefetch_related("tags", "images", "attachments")
+            )
+            permission_classes = [IsAuthenticatedOrReadOnly]
+
+            def get_serializer_class(self) -> type[Serializer[Any]]:
+                if self.request.method in ("PUT", "PATCH"):
+                    return RecruitmentCreateUpdateSerializer
+                return RecruitmentDetailSerializer
+
+            def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+                instance = self.get_object()
+                increase_views(instance)
+                serializer = self.get_serializer(instance, context={"request": request})
+                return Response(serializer.data)
+
+            def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+                """PUT/PATCH 시에는 create/update serializer로 검증 → detail serializer로 응답"""
+                instance = self.get_object()
+                serializer = RecruitmentCreateUpdateSerializer(instance, data=request.data, partial=False)
+                serializer.is_valid(raise_exception=True)
+                updated_instance = update_recruitment(instance, serializer.validated_data)
+
+                response_serializer = RecruitmentDetailSerializer(updated_instance, context={"request": request})
+                return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+            def perform_update(self, serializer: BaseSerializer[Any]) -> None:
+                recruitment = self.get_object()
+                update_recruitment(recruitment, serializer.validated_data)
 
         response_serializer = RecruitmentDetailSerializer(updated_instance, context={"request": request})
         return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/apps/recruitments/views/tag_views.py
+++ b/apps/recruitments/views/tag_views.py
@@ -58,7 +58,7 @@ class TagAPIView(APIView):
         return Response(serializer.data, status=201)
 
     def get_queryset(self, request: Request) -> QuerySet[Tag]:
-        queryset = Tag.objects.all()
+        queryset = Tag.objects.all().order_by("name")
         keyword = request.query_params.get("search")
 
         if keyword:


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: recruitments_id 로 받는것을 recruitments_uuid로 받게 수정
- 
## 📄 상세 내용
- [x] 입력값을 recruitments_id 로 받는것을 recruitments_uuid로 받게 수정
- [x] 출력값 중 study_group_id --> study_group_uuid 로 수정
- [ ] 주요 변경 사항 3

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
