### PR TITLE
[Feature/recruitments applications/me/juhyun] 내가 지원한 공고 내역 조회 API 응답에 강의 목록, 태그 목록 추가

### DIFF
--- a/apps/recruitments/serializers/my_application_serializers.py
+++ b/apps/recruitments/serializers/my_application_serializers.py
@@ -51,6 +51,9 @@ class MyApplicationSerializer(RecruitmentPresentationMixin, serializers.Serializ
     expected_headcount = serializers.IntegerField(source="recruitment.expected_headcount")
     deadline = serializers.SerializerMethodField()
 
+    lectures = serializers.SerializerMethodField()
+    tags = serializers.SerializerMethodField()
+
     def get_uuid(self, obj: Application) -> str:
         val = getattr(obj, "uuid", None)
         return str(val) if val is not None else str(obj.id)
@@ -61,6 +64,26 @@ class MyApplicationSerializer(RecruitmentPresentationMixin, serializers.Serializ
 
     def get_deadline(self, obj: Application) -> str:
         return RecruitmentPresentationMixin.deadline_date(obj.recruitment)
+
+    def get_lectures(self, obj: Application) -> list[str]:
+        """
+        recruitment.study_group.lectures 의 title만 뽑아 배열로 반환.
+        """
+        rec = obj.recruitment
+        group = getattr(rec, "study_group", None)
+        if group is None:
+            return []
+        lectures = getattr(group, "lectures", None)
+        if lectures is None:
+            return []
+        return list(lectures.order_by("id").values_list("title", flat=True))
+
+    def get_tags(self, obj: Application) -> list[str]:
+        rec = obj.recruitment
+        tags_mgr = getattr(rec, "tags", None)
+        if tags_mgr is None:
+            return []
+        return list(tags_mgr.order_by("id").values_list("name", flat=True))
 
 
 class MyApplicationRecruitmentBriefSerializer(RecruitmentPresentationMixin, serializers.Serializer[Any]):

--- a/apps/recruitments/tests/test_my_applications.py
+++ b/apps/recruitments/tests/test_my_applications.py
@@ -135,6 +135,16 @@ class MyApplicationsAPITests(APITestCase):
             self.assertIn("expected_headcount", it)
             self.assertIn("deadline", it)  # YYYY-MM-DD
 
+            self.assertIn("lectures", it)
+            self.assertIsInstance(it["lectures"], list)
+            for lec in it["lectures"]:
+                self.assertIsInstance(lec, str)
+
+            self.assertIn("tags", it)
+            self.assertIsInstance(it["tags"], list)
+            for tag in it["tags"]:
+                self.assertIsInstance(tag, str)
+
         # 이미지 규칙: recruitment1만 이미지 존재 → 해당 아이템에서는 URL, 다른 하나는 null
         # second가 recruitment1(백엔드)이므로 이미지 있음
         self.assertEqual(second["recruitment_img"], "https://cdn.example.com/study.png")

--- a/apps/recruitments/views/my_application_views.py
+++ b/apps/recruitments/views/my_application_views.py
@@ -40,10 +40,9 @@ class MyApplicationsAPIView(APIView):
             Application.objects.filter(user=cast(User, request.user))
             .select_related("recruitment")
             .prefetch_related(
-                Prefetch(
-                    "recruitment__images",
-                    queryset=RecruitmentImage.objects.order_by("id"),
-                )
+                Prefetch("recruitment__images", queryset=RecruitmentImage.objects.order_by("id")),
+                "recruitment__study_group__lectures",
+                "recruitment__tags",
             )
             .order_by("-created_at")
         )


### PR DESCRIPTION
## ✅ PR 요약
- 내가 지원한 공고 내역 조회 API 응답에 강의 목록, 태그 목록 추가

## 📄 상세 내용
- [x] 내가 지원한 공고 내역 조회 API Serializer, View, TestCode 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
