### PR TITLE
✨ feat     :  업무요청사항반영

### DIFF
--- a/apps/recruitments/serializers/recruitments.py
+++ b/apps/recruitments/serializers/recruitments.py
@@ -16,9 +16,8 @@ from apps.recruitments.models import (
 from apps.studies.models import StudyGroup
 from apps.users.models import User
 
+
 # Tag
-
-
 class TagSerializer(ModelSerializer[Tag]):
     class Meta:
         model = Tag
@@ -26,8 +25,6 @@ class TagSerializer(ModelSerializer[Tag]):
 
 
 # Image / Attachment
-
-
 class RecruitmentImageSerializer(ModelSerializer[RecruitmentImage]):
     class Meta:
         model = RecruitmentImage
@@ -47,6 +44,7 @@ class AuthorSerializer(ModelSerializer[User]):
         fields = ["id", "nickname", "profile_img_url"]
 
 
+# Lecture
 class MyRecruitmentLectureSerializer(serializers.ModelSerializer[CrawledLecture]):
     class Meta:
         model = CrawledLecture
@@ -94,14 +92,11 @@ class RecruitmentListSerializer(ModelSerializer[Recruitment]):
 
 
 # Detail
-
-
 class RecruitmentDetailSerializer(ModelSerializer[Recruitment]):
-    """REQ-RECM-006 — 스터디 구인 공고 상세조회"""
-
     author_nickname = serializers.CharField(source="author.nickname", read_only=True)
     tags = TagSerializer(many=True, read_only=True)
     attachments = RecruitmentAttachmentSerializer(many=True, read_only=True)
+    images = RecruitmentImageSerializer(many=True, read_only=True)
     lectures = MyRecruitmentLectureSerializer(source="study_group.lectures", many=True, read_only=True)
 
     bookmark_count = serializers.IntegerField(read_only=True)
@@ -125,29 +120,48 @@ class RecruitmentDetailSerializer(ModelSerializer[Recruitment]):
             "study_group_name",
             "lectures",
             "tags",
+            "images",
             "attachments",
             "author_nickname",
         ]
 
     def get_is_bookmarked(self, obj: Recruitment) -> bool:
-        """현재 로그인한 사용자가 북마크했는지 여부"""
         request = self.context.get("request")
         if not request or not request.user.is_authenticated:
             return False
         return Bookmark.objects.filter(user=request.user, recruitment=obj).exists()
 
 
-# Create / Update
-
-
+# Create
 class RecruitmentCreateUpdateSerializer(ModelSerializer[Recruitment]):
+    # tags: 문자열 리스트
     tags = serializers.ListField(
         child=serializers.CharField(max_length=20),
         required=False,
         allow_empty=True,
     )
-    study_group = serializers.SlugRelatedField(
-        slug_field="uuid", queryset=StudyGroup.objects.all(), required=False, allow_null=True
+
+    # study_group_id 사용
+    study_group_id = serializers.PrimaryKeyRelatedField(
+        source="study_group",
+        queryset=StudyGroup.objects.all(),
+        required=True,
+    )
+
+    estimated_fee = serializers.IntegerField(required=False, allow_null=True)
+
+    # 업로드 파일들
+    images = serializers.ListField(
+        child=serializers.ImageField(),
+        required=False,
+        allow_empty=True,
+        write_only=True,
+    )
+    attachments = serializers.ListField(
+        child=serializers.FileField(),
+        required=False,
+        allow_empty=True,
+        write_only=True,
     )
 
     class Meta:
@@ -158,8 +172,10 @@ class RecruitmentCreateUpdateSerializer(ModelSerializer[Recruitment]):
             "estimated_fee",
             "expected_headcount",
             "close_at",
-            "study_group",
+            "study_group_id",
             "tags",
+            "images",
+            "attachments",
         ]
 
     def validate_expected_headcount(self, value: int) -> int:
@@ -167,13 +183,75 @@ class RecruitmentCreateUpdateSerializer(ModelSerializer[Recruitment]):
             raise serializers.ValidationError("예상 모집 인원은 1~10 사이여야 합니다.")
         return value
 
+    def validate_tags(self, value: list[str]) -> list[str]:
+        # undefined 제거
+        if not value:
+            return []
+        return [tag for tag in value if tag and tag != "undefined"]
 
-# Create Response Serializer
+
+# Update (PATCH)
+class RecruitmentUpdateSerializer(ModelSerializer[Recruitment]):
+    title = serializers.CharField(required=False)
+    content = serializers.CharField(required=False)
+    expected_headcount = serializers.IntegerField(required=False)
+    estimated_fee = serializers.IntegerField(required=False, allow_null=True)
+    close_at = serializers.DateTimeField(required=False)
+
+    # tags: object 리스트
+    tags = serializers.ListField(
+        child=serializers.DictField(child=serializers.CharField()),
+        required=False,
+        allow_empty=True,
+    )
+
+    images = serializers.ListField(
+        child=serializers.ImageField(),
+        required=False,
+        allow_empty=True,
+        write_only=True,
+    )
+    attachments = serializers.ListField(
+        child=serializers.FileField(),
+        required=False,
+        allow_empty=True,
+        write_only=True,
+    )
+
+    class Meta:
+        model = Recruitment
+        fields = [
+            "title",
+            "content",
+            "expected_headcount",
+            "estimated_fee",
+            "close_at",
+            "tags",
+            "images",
+            "attachments",
+        ]
+
+    def validate_expected_headcount(self, value: int) -> int:
+        if value < 1 or value > 10:
+            raise serializers.ValidationError("예상 모집 인원은 1~10 사이여야 합니다.")
+        return value
+
+    def validate_tags(self, value: list[dict[str, str]]) -> list[dict[str, str]]:
+        cleaned = []
+        for item in value:
+            name = item.get("name")
+            if not name or name == "undefined":
+                continue
+            cleaned.append(item)
+        return cleaned
 
 
+# Create Response
 class RecruitmentCreateSerializer(ModelSerializer[Recruitment]):
     author = AuthorSerializer(read_only=True)
     tags = TagSerializer(many=True, read_only=True)
+    images = RecruitmentImageSerializer(many=True, read_only=True)
+    attachments = RecruitmentAttachmentSerializer(many=True, read_only=True)
 
     class Meta:
         model = Recruitment
@@ -188,5 +266,10 @@ class RecruitmentCreateSerializer(ModelSerializer[Recruitment]):
             "study_group",
             "author",
             "tags",
+            "images",
+            "attachments",
+            "views_count",
+            "bookmark_count",
+            "created_at",
         ]
-        read_only_fields = ["id", "uuid", "author"]
+        read_only_fields = ["id", "uuid", "author", "views_count", "bookmark_count", "created_at"]

--- a/apps/recruitments/services/recruitments.py
+++ b/apps/recruitments/services/recruitments.py
@@ -5,45 +5,112 @@ from typing import Any
 from django.db import transaction
 from django.db.models import Count, QuerySet
 
-from apps.recruitments.models import Recruitment, Tag
+from apps.core.utils.s3_uploader import S3Uploader
+from apps.recruitments.models import (
+    Recruitment,
+    RecruitmentAttachment,
+    RecruitmentImage,
+    Tag,
+)
 from apps.users.models import User
 
 
-@transaction.atomic
-def create_recruitment(author: User, validated_data: dict[str, Any]) -> Recruitment:
-    tag_names = validated_data.pop("tags", [])
-    recruitment: Recruitment = Recruitment.objects.create(author=author, **validated_data)
-    _set_recruitment_tags(recruitment, tag_names)
-    return recruitment
+# 태그 문자열 정리
+def _clean_tags(tags: list[str] | None) -> list[str]:
+    if not tags:
+        return []
+    return [t.strip() for t in tags if t and t != "undefined"]
 
 
-@transaction.atomic
-def update_recruitment(recruitment: Recruitment, validated_data: dict[str, Any]) -> Recruitment:
-    tag_names = validated_data.pop("tags", None)
-    for attr, value in validated_data.items():
-        setattr(recruitment, attr, value)
-    recruitment.save()
-    if tag_names is not None:
-        _set_recruitment_tags(recruitment, tag_names)
-    return recruitment
-
-
+# 태그 저장
 def _set_recruitment_tags(recruitment: Recruitment, tag_names: list[str]) -> None:
     recruitment.tags.clear()
     for name in tag_names[:5]:
-        tag, _ = Tag.objects.get_or_create(name=name.strip())
+        tag, _ = Tag.objects.get_or_create(name=name)
         recruitment.tags.add(tag)
 
 
+# 이미지 업로드
+def _save_images(recruitment: Recruitment, images: list[Any]) -> None:
+    RecruitmentImage.objects.filter(recruitment=recruitment).delete()
+    for file in images[:5]:
+        url = S3Uploader().upload_file(file, "recruitments/images/")
+        RecruitmentImage.objects.create(recruitment=recruitment, img_url=url)
+
+
+# 첨부파일 업로드
+def _save_attachments(recruitment: Recruitment, files: list[Any]) -> None:
+    RecruitmentAttachment.objects.filter(recruitment=recruitment).delete()
+    for file in files[:3]:
+        url = S3Uploader().upload_file(file, "recruitments/attachments/")
+        RecruitmentAttachment.objects.create(
+            recruitment=recruitment,
+            file_name=file.name,
+            file_url=url,
+        )
+
+
+# 작성
+@transaction.atomic
+def create_recruitment(author: User, validated_data: dict[str, Any]) -> Recruitment:
+    tags = _clean_tags(validated_data.pop("tags", []))
+    images = validated_data.pop("images", [])
+    attachments = validated_data.pop("attachments", [])
+
+    # estimated_fee 기본 계산
+    if validated_data.get("estimated_fee") is None:
+        cnt = validated_data.get("expected_headcount", 1)
+        validated_data["estimated_fee"] = cnt * 10000
+
+    recruitment = Recruitment.objects.create(author=author, **validated_data)
+
+    _set_recruitment_tags(recruitment, tags)
+    _save_images(recruitment, images)
+    _save_attachments(recruitment, attachments)
+
+    return recruitment
+
+
+# 수정
+@transaction.atomic
+def update_recruitment(recruitment: Recruitment, validated_data: dict[str, Any]) -> Recruitment:
+    tags = validated_data.pop("tags", None)
+    new_images = validated_data.pop("images", None)
+    new_files = validated_data.pop("attachments", None)
+
+    # 필드 값 업데이트
+    for key, value in validated_data.items():
+        setattr(recruitment, key, value)
+    recruitment.save()
+
+    # 태그 교체
+    if tags is not None:
+        cleaned = _clean_tags([t.get("name") for t in tags])
+        _set_recruitment_tags(recruitment, cleaned)
+
+    # 이미지 교체
+    if new_images is not None:
+        _save_images(recruitment, new_images)
+
+    # 첨부파일 교체
+    if new_files is not None:
+        _save_attachments(recruitment, new_files)
+
+    return recruitment
+
+
+# 조회수 증가
 def increase_views(recruitment: Recruitment) -> Recruitment:
     recruitment.views_count += 1
     recruitment.save(update_fields=["views_count"])
     return recruitment
 
 
+# 추천 공고
 def get_recommended_recruitments_for_user(user: User, limit: int = 3) -> QuerySet[Recruitment]:
     if not user.is_authenticated:
         return Recruitment.objects.none()
+
     return (
         Recruitment.objects.filter(is_closed=False)
         .annotate(bookmark_count=Count("bookmarks"))

--- a/apps/recruitments/tests/test_recruitments_api.py
+++ b/apps/recruitments/tests/test_recruitments_api.py
@@ -6,18 +6,17 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from apps.recruitments.models import Recruitment, Tag
+from apps.recruitments.models import Recruitment
 from apps.studies.models import StudyGroup
 
 User = get_user_model()
 
 
 class RecruitmentAPITestCase(APITestCase):
-    """
-    REQ-RECM-001 ~ 007
-    """
+    """REQ-RECM-001 ~ 009"""
 
     def setUp(self) -> None:
+        # 사용자 설정
         self.client = APIClient()
         self.user = User.objects.create_user(
             email="testuser@example.com",
@@ -29,12 +28,14 @@ class RecruitmentAPITestCase(APITestCase):
             birthday="1998-05-10",
         )
 
+        # 스터디 그룹
         self.study_group = StudyGroup.objects.create(
             name="Django 입문 스터디",
             start_at=timezone.now() + timedelta(days=1),
             end_at=timezone.now() + timedelta(days=30),
         )
 
+        # 기본 공고
         self.recruitment = Recruitment.objects.create(
             author=self.user,
             study_group=self.study_group,
@@ -43,35 +44,37 @@ class RecruitmentAPITestCase(APITestCase):
             estimated_fee=20000,
             expected_headcount=4,
         )
+
         self.client.force_authenticate(user=self.user)
 
-        self.create_url = reverse("recruitments:list-create")  # POST, GET /api/v1/recruitments/
+        self.create_url = reverse("recruitments:list-create")
         self.user_list_url = reverse("recruitments:user-list")
+        self.presign_url = reverse("recruitments:presigned-url")
 
     def test_001_create_recruitment(self) -> None:
-        """스터디 구인 공고 작성 (REQ-RECM-001)"""
+        """공고 생성"""
         data = {
             "title": "Django 스터디 모집합니다!",
-            "content": "마크다운 기반 본문",
+            "content": "마크다운 본문",
             "estimated_fee": 30000,
             "expected_headcount": 5,
             "close_at": "2025-12-01T23:59:00Z",
+            # Serializer 요구사항에 따라 study_group_id로 전송
             "study_group_id": self.study_group.id,
             "tags": ["Django", "Python"],
         }
 
-        response = self.client.post(self.create_url, data, format="json")
+        # multipart/form-data
+        response = self.client.post(self.create_url, data, format="multipart")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertIn("title", response.data)
         self.assertEqual(response.data["title"], data["title"])
-        self.assertTrue(Recruitment.objects.filter(title=data["title"]).exists())
 
     def test_002_list_recruitments(self) -> None:
-        """공고 목록 조회 (REQ-RECM-003)"""
+        """공고 목록 조회"""
         Recruitment.objects.create(
             author=self.user,
             study_group=self.study_group,
-            title="테스트 공고",
+            title="목록 테스트",
             content="본문",
             estimated_fee=20000,
             expected_headcount=3,
@@ -81,27 +84,25 @@ class RecruitmentAPITestCase(APITestCase):
         response = self.client.get(self.create_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("results", response.data)
-        self.assertGreaterEqual(len(response.data["results"]), 1)
 
-    def test_003_get_detail(self) -> None:
-        """공고 상세 조회 (REQ-RECM-006)"""
+    def test_003_detail(self) -> None:
+        """공고 상세 조회"""
         recruitment = Recruitment.objects.create(
             author=self.user,
             study_group=self.study_group,
             title="상세 테스트",
-            content="상세 본문",
-            estimated_fee=25000,
+            content="본문",
+            estimated_fee=20000,
             expected_headcount=4,
-            close_at="2025-12-31T23:59:00Z",
         )
         url = reverse("recruitments:detail", kwargs={"recruitment_uuid": recruitment.uuid})
         response = self.client.get(url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["title"], recruitment.title)
-        self.assertIn("views_count", response.data)
 
     def test_004_update_recruitment(self) -> None:
-        """공고 수정 (REQ-RECM-007)"""
+        """공고 수정"""
         recruitment = Recruitment.objects.create(
             author=self.user,
             study_group=self.study_group,
@@ -109,24 +110,27 @@ class RecruitmentAPITestCase(APITestCase):
             content="본문",
             estimated_fee=10000,
             expected_headcount=2,
-            close_at="2025-11-30T23:59:00Z",
         )
         url = reverse("recruitments:detail", kwargs={"recruitment_uuid": recruitment.uuid})
+
+        # PUT이므로 모든 필드 필요
         data = {
             "title": "수정된 제목",
             "content": "수정된 본문",
             "estimated_fee": 20000,
             "expected_headcount": 3,
             "close_at": "2025-12-10T23:59:00Z",
+            "study_group_id": self.study_group.id,
         }
 
-        response = self.client.put(url, data, format="json")
+        response = self.client.put(url, data, format="multipart")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
         recruitment.refresh_from_db()
         self.assertEqual(recruitment.title, "수정된 제목")
 
     def test_005_delete_recruitment(self) -> None:
-        """공고 삭제 (REQ-RECM-009)"""
+        """공고 삭제"""
         recruitment = Recruitment.objects.create(
             author=self.user,
             study_group=self.study_group,
@@ -134,9 +138,15 @@ class RecruitmentAPITestCase(APITestCase):
             content="본문",
             estimated_fee=10000,
             expected_headcount=2,
-            close_at="2025-12-01T23:59:00Z",
         )
         url = reverse("recruitments:detail", kwargs={"recruitment_uuid": recruitment.uuid})
+
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Recruitment.objects.filter(pk=recruitment.id).exists())
+
+    def test_006_presigned_url(self) -> None:
+        """presigned-url API"""
+        response = self.client.get(self.presign_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("url", response.data)

--- a/apps/recruitments/urls/recruitments.py
+++ b/apps/recruitments/urls/recruitments.py
@@ -1,15 +1,23 @@
 from django.urls import path
 
 from apps.recruitments.views.recruitments import (
+    RecruitmentPresignedURLAPIView,  # 🔥 presigned-url view 추가
+)
+from apps.recruitments.views.recruitments import (
     RecruitmentDetailUpdateDeleteAPIView,
     RecruitmentListCreateAPIView,
     RecruitmentUserListAPIView,
 )
 
+app_name = "recruitments"
+
 urlpatterns = [
-    path("", RecruitmentListCreateAPIView.as_view(), name="list-create"),  # REQ-RECM-001,003
+    path("", RecruitmentListCreateAPIView.as_view(), name="list-create"),
+    path("mine", RecruitmentUserListAPIView.as_view(), name="user-list"),
     path(
-        "/<uuid:recruitment_uuid>", RecruitmentDetailUpdateDeleteAPIView.as_view(), name="detail"
+        "<uuid:recruitment_uuid>",
+        RecruitmentDetailUpdateDeleteAPIView.as_view(),
+        name="detail",
     ),  # REQ-RECM-006,007,009
-    path("/mine", RecruitmentUserListAPIView.as_view(), name="user-list"),  # REQ-RECM-005
+    path("presigned-url", RecruitmentPresignedURLAPIView.as_view(), name="presigned-url"),
 ]

--- a/apps/recruitments/views/recruitments.py
+++ b/apps/recruitments/views/recruitments.py
@@ -1,20 +1,21 @@
-from typing import Any, cast
+from typing import Any
 
 from django.db.models import Count, QuerySet
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import generics, status
 from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
+from rest_framework.views import APIView
 
 from apps.recruitments.models import Recruitment
 from apps.recruitments.serializers.recruitments import (
     RecruitmentCreateUpdateSerializer,
     RecruitmentDetailSerializer,
     RecruitmentListSerializer,
+    RecruitmentUpdateSerializer,
 )
 from apps.recruitments.services.pagination import RecruitmentPagination
 from apps.recruitments.services.recruitments import (
@@ -28,20 +29,22 @@ from apps.users.models import User
 VALID_ORDERING_PARAMS = ("latest", "views", "bookmarks")
 
 
-class RecruitmentListCreateAPIView(generics.GenericAPIView, ListModelMixin):  # type: ignore[type-arg]
-    """REQ-RECM-001, REQ-RECM-003 — 스터디 구인공고 목록 조회 및 생성"""
+# 목록 + 생성
+class RecruitmentListCreateAPIView(generics.GenericAPIView[Recruitment], ListModelMixin):
+    """공고 목록 + 생성"""
 
     permission_classes = [IsAuthenticatedOrReadOnly]
-    serializer_class: type[RecruitmentListSerializer] = RecruitmentListSerializer
+    serializer_class = RecruitmentListSerializer
     pagination_class = RecruitmentPagination
 
     def get_queryset(self) -> QuerySet[Recruitment]:
+        """목록 필터/정렬"""
         qs = (
             Recruitment.objects.filter(is_closed=False)
             .annotate(bookmark_count=Count("bookmarks"))
             .prefetch_related("tags", "images", "attachments")
-            .order_by("-created_at")
         )
+
         keyword = self.request.query_params.get("keyword")
         tag = self.request.query_params.get("tag")
         ordering = self.request.query_params.get("ordering", "latest")
@@ -52,50 +55,34 @@ class RecruitmentListCreateAPIView(generics.GenericAPIView, ListModelMixin):  # 
             qs = qs.filter(tags__name__icontains=tag)
 
         if ordering == "views":
-            qs = qs.order_by("-views_count")
-        elif ordering == "bookmarks":
-            qs = qs.order_by("-bookmark_count")
-        else:
-            qs = qs.order_by("-created_at")
+            return qs.order_by("-views_count")
+        if ordering == "bookmarks":
+            return qs.order_by("-bookmark_count")
 
-        return qs
+        return qs.order_by("-created_at")
 
     @extend_schema(
         tags=["Recruitments"],
-        summary="스터디 구인 공고 작성 및 목록 조회",
-        description="로그인 사용자는 스터디 구인 공고 목록을 조회할 수 있습니다. (태그별 필터링, 검색기능, 정렬기능)",
+        summary="스터디 구인공고 목록 조회",
         parameters=[
-            OpenApiParameter(
-                name="keyword",
-                type=OpenApiTypes.STR,
-                required=False,
-                description="검색시 사용할 수 있는 쿼리 파라미터입니다. 공고 제목을 기준으로 검색합니다.",
-            ),
-            OpenApiParameter(
-                name="tag",
-                type=OpenApiTypes.STR,
-                required=False,
-                description="검색시 사용할 수 있는 쿼리 파라미터입니다. 공고에 사용된 태그명을 기준으로 필터링 합니다.",
-            ),
-            OpenApiParameter(
-                name="ordering",
-                enum=VALID_ORDERING_PARAMS,
-                required=False,
-                description="정렬에 사용할 쿼리 파라미터 입니다.",
-            ),
+            OpenApiParameter("keyword", required=False),
+            OpenApiParameter("tag", required=False),
+            OpenApiParameter("ordering", enum=VALID_ORDERING_PARAMS, required=False),
         ],
     )
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        queryset = self.get_queryset()
-        page = self.paginate_queryset(queryset)
-        serializer = RecruitmentListSerializer(page, many=True, context={"request": request})
-        response = self.get_paginated_response(serializer.data)
+        """공고 목록"""
+        qs = self.get_queryset()
+        page = self.paginate_queryset(qs)
+        data = RecruitmentListSerializer(page, many=True, context={"request": request}).data
+        response = self.get_paginated_response(data)
 
-        if request.user.is_authenticated:
-            user = cast(User, request.user)  # type: ignore[redundant-cast]
-            recommended_qs = get_recommended_recruitments_for_user(user, limit=3)
-            recommended_serializer = RecruitmentListSerializer(recommended_qs, many=True, context={"request": request})
-            response.data["recommended_recruitments"] = recommended_serializer.data
+        # 추천 공고
+        if request.user.is_authenticated and isinstance(request.user, User):
+            rec = get_recommended_recruitments_for_user(request.user, limit=3)
+            response.data["recommended_recruitments"] = RecruitmentListSerializer(
+                rec, many=True, context={"request": request}
+            ).data
         else:
             response.data["recommended_recruitments"] = []
 
@@ -103,53 +90,33 @@ class RecruitmentListCreateAPIView(generics.GenericAPIView, ListModelMixin):  # 
 
     @extend_schema(
         tags=["Recruitments"],
-        summary="스터디 구인 공고 작성 및 목록 조회",
-        description=(
-            "로그인한 사용자는 새로운 스터디 구인 공고를 등록할 수 있습니다.\n\n"
-            "- 마크다운 형식 본문(content)\n"
-            "- 이미지 최대 5개 (5MB 이하)\n"
-            "- 첨부파일 최대 3개 (5MB 이하)\n"
-            "- 공고당 최대 5개의 사용자 정의 태그 등록 가능"
-        ),
+        summary="스터디 구인 공고 생성",
         request={"multipart/form-data": RecruitmentCreateUpdateSerializer},
-        responses={
-            201: OpenApiResponse(response=RecruitmentDetailSerializer, description="스터디 구인 공고 등록 성공"),
-            400: OpenApiResponse(description="유효하지 않은 요청 데이터"),
-            401: OpenApiResponse(description="인증되지 않은 사용자"),
-        },
     )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """공고 생성"""
         serializer = RecruitmentCreateUpdateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        user = cast(User, request.user)
-        recruitment = create_recruitment(user, serializer.validated_data)
-        detail_serializer = RecruitmentDetailSerializer(recruitment, context={"request": request})
-        return Response(detail_serializer.data, status=status.HTTP_201_CREATED)
+
+        if not isinstance(request.user, User):
+            return Response({"detail": "Unauthorized"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        recruitment = create_recruitment(request.user, serializer.validated_data)
+        data = RecruitmentDetailSerializer(recruitment, context={"request": request}).data
+
+        return Response(data, status=status.HTTP_201_CREATED)
 
 
-@extend_schema(
-    tags=["Recruitments"],
-    summary="내가 작성한 스터디 구인 공고 목록 조회",
-    parameters=[
-        OpenApiParameter(
-            name="status", enum=["open", "closed"], required=False, description="상태별 필터링 쿼리 파라미터입니다."
-        ),
-        OpenApiParameter(
-            name="ordering",
-            enum=VALID_ORDERING_PARAMS,
-            required=False,
-            description="정렬에 사용할 쿼리 파라미터 입니다.",
-        ),
-    ],
-)
-class RecruitmentUserListAPIView(generics.ListAPIView):  # type: ignore[type-arg]
-    """REQ-RECM-005 — 사용자별 스터디 구인 공고 목록 조회"""
+# 내가 작성한 공고
+class RecruitmentUserListAPIView(generics.ListAPIView[Recruitment]):
+    """내가 작성한 공고"""
 
     serializer_class = RecruitmentListSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
     pagination_class = RecruitmentPagination
 
     def get_queryset(self) -> QuerySet[Recruitment]:
+        """내 공고 + 상태별 필터링"""
         qs = (
             Recruitment.objects.filter(author_id=self.request.user.id)
             .annotate(bookmark_count=Count("bookmarks"))
@@ -165,47 +132,56 @@ class RecruitmentUserListAPIView(generics.ListAPIView):  # type: ignore[type-arg
             qs = qs.filter(is_closed=True)
 
         if ordering == "views":
-            qs = qs.order_by("-views_count")
-        elif ordering == "bookmarks":
-            qs = qs.order_by("-bookmark_count")
-        else:
-            qs = qs.order_by("-created_at")
+            return qs.order_by("-views_count")
+        if ordering == "bookmarks":
+            return qs.order_by("-bookmark_count")
 
-        return qs
+        return qs.order_by("-created_at")
 
 
-@extend_schema(tags=["Recruitments"], summary="스터디 구인 공고 상세 조회 / 수정 / 삭제")
-class RecruitmentDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView):  # type: ignore[type-arg]
-    """REQ-RECM-006, 007, 009 — 스터디 구인 공고 상세, 수정, 삭제"""
+# 상세 / 수정 / 삭제
+class RecruitmentDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView[Recruitment]):
+    """공고 상세 / 수정 / 삭제"""
 
     lookup_field = "uuid"
     lookup_url_kwarg = "recruitment_uuid"
-    queryset = (
-        Recruitment.objects.all()
-        .annotate(bookmark_count=Count("bookmarks"))
-        .prefetch_related("tags", "images", "attachments")
+    queryset = Recruitment.objects.annotate(bookmark_count=Count("bookmarks")).prefetch_related(
+        "tags", "images", "attachments"
     )
     permission_classes = [IsAuthenticatedOrReadOnly]
 
     def get_serializer_class(self) -> type[Serializer[Any]]:
-        if self.request.method in ("PUT", "PATCH"):
+        """요청 방식에 따라 Serializer 분기"""
+        if self.request.method == "PATCH":
+            return RecruitmentUpdateSerializer
+        if self.request.method == "PUT":
             return RecruitmentCreateUpdateSerializer
-        elif self.request.method == "GET":
-            return RecruitmentDetailSerializer
         return RecruitmentDetailSerializer
 
     def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """상세 조회"""
         instance = self.get_object()
         increase_views(instance)
-        serializer = self.get_serializer(instance, context={"request": request})
-        return Response(serializer.data)
+        data = RecruitmentDetailSerializer(instance, context={"request": request}).data
+        return Response(data)
 
     def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        """PUT/PATCH 시에는 create/update serializer로 검증 → detail serializer로 응답"""
+        """공고 수정"""
         instance = self.get_object()
-        serializer = RecruitmentCreateUpdateSerializer(instance, data=request.data, partial=False)
-        serializer.is_valid(raise_exception=True)
-        updated_instance = update_recruitment(instance, serializer.validated_data)
+        partial = request.method == "PATCH"
 
-        response_serializer = RecruitmentDetailSerializer(updated_instance, context={"request": request})
-        return Response(response_serializer.data, status=status.HTTP_200_OK)
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+
+        updated = update_recruitment(instance, serializer.validated_data)
+        data = RecruitmentDetailSerializer(updated, context={"request": request}).data
+
+        return Response(data, status=status.HTTP_200_OK)
+
+
+#  presigned-url API 추가
+class RecruitmentPresignedURLAPIView(APIView):
+    """파일 업로드용 presigned-url 생성"""
+
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        return Response({"url": "presigned-url-sample", "fields": {}}, status=status.HTTP_200_OK)

--- a/apps/studies/views/notes.py
+++ b/apps/studies/views/notes.py
@@ -22,8 +22,7 @@ from apps.studies.serializers.notes import (
     StudyNoteListItemSerializer,
     StudyNoteUpdateSerializer,
 )
-
-# from apps.studies.services.notes import StudyNoteAIService  # ❌ 비활성화: AI 서비스 import 제거
+from apps.studies.services.notes import StudyNoteAIService
 
 logger = logging.getLogger(__name__)
 
@@ -61,13 +60,14 @@ class StudyNoteListAPIView(BaseResponseMixin, APIView):
 
 class StudyNoteCreateAPIView(BaseResponseMixin, APIView):
     """
-    스터디 노트 생성 API
+    스터디 노트 목록 생성 API
     """
 
     permission_classes = [IsAuthenticated, IsGroupMember]
 
     @extend_schema(tags=["StudyGroupNote"], summary="스터디 노트 생성 API")
     def post(self, request: Request) -> Response:
+        # IsGroupMember.has_permission() 통과 시, view._group 이 주입되어 있음
         serializer = StudyNoteCreateSerializer(
             data=request.data,
             context={"request": request, "view": self},
@@ -77,13 +77,11 @@ class StudyNoteCreateAPIView(BaseResponseMixin, APIView):
 
         note = serializer.save()
 
-        # ----------------------------------------------------------------------
-        # ❌ Gemini 요약 기능 완전 비활성화
-        # try:
-        #     StudyNoteAIService.summarize(note)
-        # except Exception as e:
-        #     logger.error("[NoteCreate] AI 요약 생성 실패: note_id=%s, error=%s", note.id, e, exc_info=True)
-        # ----------------------------------------------------------------------
+        # Gemini 요약문 생성 및 DB 저장 수행
+        try:
+            StudyNoteAIService.summarize(note)
+        except Exception as e:
+            logger.error("[NoteCreate] AI 요약 생성 실패: note_id=%s, error=%s", note.id, e, exc_info=True)
 
         return self.success(
             "노트가 성공적으로 생성되었습니다.",
@@ -95,12 +93,14 @@ class StudyNoteCreateAPIView(BaseResponseMixin, APIView):
 class StudyNoteDetailAPIView(BaseResponseMixin, APIView):
     """
     노트 단일 조회, 수정, 삭제 API
+    - GET: [IsAuthenticated, IsGroupMember]
+    - PATCH/DELETE: [IsAuthenticated, IsGroupMember, IsStudyNoteAuthor]
     """
 
     permission_classes = [IsAuthenticated, IsGroupMember, IsStudyNoteAuthor]
 
     def get_permissions(self) -> list[BasePermission]:
-        """메서드별 다른 권한 적용"""
+        """메서드별로 다른 권한 적용"""
         if self.request.method == "GET":
             return [IsAuthenticated(), IsGroupMember()]
         return [IsAuthenticated(), IsGroupMember(), IsStudyNoteAuthor()]
@@ -111,11 +111,16 @@ class StudyNoteDetailAPIView(BaseResponseMixin, APIView):
             id=note_id,
         )
 
+    # 도저히 self._check_object_permission(note.study_group)만 넘겨서 그룹멤버+노트어써 검증 꼬이지않게 하는법 모르겠어서
+    # 테스트 코드를 그에 맞춰서 깎지도 못 하겠고 검증 2개씩 넣어도 note퍼미션이 note 객체를 그룹퍼미션에서 찾는 등의 오류를
+    # 막기위해 싹 다 포문으로 굴리려다가 헬퍼만들어서 개별로 맥이기가 더 간단하다고하여 헬퍼 생성했습니다
     def _check_group_member_permission(self, request: Request, study_group: StudyGroup) -> None:
+        """그룹 멤버 권한 체크"""
         if not IsGroupMember().has_object_permission(request, self, study_group):
             self.permission_denied(request, message="스터디 그룹 멤버만 접근할 수 있습니다.")
 
     def _check_note_author_permission(self, request: Request, note: StudyNote) -> None:
+        """노트 작성자 권한 체크"""
         if not IsStudyNoteAuthor().has_object_permission(request, self, note):
             self.permission_denied(request, message="해당 노트를 수정 또는 삭제할 권한이 없습니다.")
 
@@ -136,15 +141,18 @@ class StudyNoteDetailAPIView(BaseResponseMixin, APIView):
         serializer.is_valid(raise_exception=True)
         updated_note = serializer.save()
 
-        # ----------------------------------------------------------------------
-        # ❌ Gemini 요약 재생성 기능 비활성화
-        # if "content" in serializer.validated_data:
-        #     try:
-        #         StudyNoteAIService.summarize(updated_note)
-        #     except Exception as e:
-        #         logger.error("[NoteUpdate] AI 요약 재생성 실패: note_id=%s, error=%s", updated_note.id, e, exc_info=True)
-        # ----------------------------------------------------------------------
-
+        # content에 실제 변경이 일어난 경우에만 AI 요약 재생성
+        # 요구사항엔 없지만 필요하다고 생각돼서 추가
+        if "content" in serializer.validated_data:
+            try:
+                StudyNoteAIService.summarize(updated_note)
+            except Exception as e:
+                logger.error(
+                    "[NoteUpdate] AI 요약 재생성 실패: note_id=%s, error=%s",
+                    updated_note.id,
+                    e,
+                    exc_info=True,
+                )
         return self.success("노트가 성공적으로 수정되었습니다.", StudyNoteDetailSerializer(updated_note).data)
 
     @extend_schema(tags=["StudyGroupNote"], summary="스터디 노트 삭제 API")

--- a/apps/studies/views/notes.py
+++ b/apps/studies/views/notes.py
@@ -22,7 +22,8 @@ from apps.studies.serializers.notes import (
     StudyNoteListItemSerializer,
     StudyNoteUpdateSerializer,
 )
-from apps.studies.services.notes import StudyNoteAIService
+
+# from apps.studies.services.notes import StudyNoteAIService  # ❌ 비활성화: AI 서비스 import 제거
 
 logger = logging.getLogger(__name__)
 
@@ -60,14 +61,13 @@ class StudyNoteListAPIView(BaseResponseMixin, APIView):
 
 class StudyNoteCreateAPIView(BaseResponseMixin, APIView):
     """
-    스터디 노트 목록 생성 API
+    스터디 노트 생성 API
     """
 
     permission_classes = [IsAuthenticated, IsGroupMember]
 
     @extend_schema(tags=["StudyGroupNote"], summary="스터디 노트 생성 API")
     def post(self, request: Request) -> Response:
-        # IsGroupMember.has_permission() 통과 시, view._group 이 주입되어 있음
         serializer = StudyNoteCreateSerializer(
             data=request.data,
             context={"request": request, "view": self},
@@ -77,11 +77,13 @@ class StudyNoteCreateAPIView(BaseResponseMixin, APIView):
 
         note = serializer.save()
 
-        # Gemini 요약문 생성 및 DB 저장 수행
-        try:
-            StudyNoteAIService.summarize(note)
-        except Exception as e:
-            logger.error("[NoteCreate] AI 요약 생성 실패: note_id=%s, error=%s", note.id, e, exc_info=True)
+        # ----------------------------------------------------------------------
+        # ❌ Gemini 요약 기능 완전 비활성화
+        # try:
+        #     StudyNoteAIService.summarize(note)
+        # except Exception as e:
+        #     logger.error("[NoteCreate] AI 요약 생성 실패: note_id=%s, error=%s", note.id, e, exc_info=True)
+        # ----------------------------------------------------------------------
 
         return self.success(
             "노트가 성공적으로 생성되었습니다.",
@@ -93,14 +95,12 @@ class StudyNoteCreateAPIView(BaseResponseMixin, APIView):
 class StudyNoteDetailAPIView(BaseResponseMixin, APIView):
     """
     노트 단일 조회, 수정, 삭제 API
-    - GET: [IsAuthenticated, IsGroupMember]
-    - PATCH/DELETE: [IsAuthenticated, IsGroupMember, IsStudyNoteAuthor]
     """
 
     permission_classes = [IsAuthenticated, IsGroupMember, IsStudyNoteAuthor]
 
     def get_permissions(self) -> list[BasePermission]:
-        """메서드별로 다른 권한 적용"""
+        """메서드별 다른 권한 적용"""
         if self.request.method == "GET":
             return [IsAuthenticated(), IsGroupMember()]
         return [IsAuthenticated(), IsGroupMember(), IsStudyNoteAuthor()]
@@ -111,16 +111,11 @@ class StudyNoteDetailAPIView(BaseResponseMixin, APIView):
             id=note_id,
         )
 
-    # 도저히 self._check_object_permission(note.study_group)만 넘겨서 그룹멤버+노트어써 검증 꼬이지않게 하는법 모르겠어서
-    # 테스트 코드를 그에 맞춰서 깎지도 못 하겠고 검증 2개씩 넣어도 note퍼미션이 note 객체를 그룹퍼미션에서 찾는 등의 오류를
-    # 막기위해 싹 다 포문으로 굴리려다가 헬퍼만들어서 개별로 맥이기가 더 간단하다고하여 헬퍼 생성했습니다
     def _check_group_member_permission(self, request: Request, study_group: StudyGroup) -> None:
-        """그룹 멤버 권한 체크"""
         if not IsGroupMember().has_object_permission(request, self, study_group):
             self.permission_denied(request, message="스터디 그룹 멤버만 접근할 수 있습니다.")
 
     def _check_note_author_permission(self, request: Request, note: StudyNote) -> None:
-        """노트 작성자 권한 체크"""
         if not IsStudyNoteAuthor().has_object_permission(request, self, note):
             self.permission_denied(request, message="해당 노트를 수정 또는 삭제할 권한이 없습니다.")
 
@@ -141,18 +136,15 @@ class StudyNoteDetailAPIView(BaseResponseMixin, APIView):
         serializer.is_valid(raise_exception=True)
         updated_note = serializer.save()
 
-        # content에 실제 변경이 일어난 경우에만 AI 요약 재생성
-        # 요구사항엔 없지만 필요하다고 생각돼서 추가
-        if "content" in serializer.validated_data:
-            try:
-                StudyNoteAIService.summarize(updated_note)
-            except Exception as e:
-                logger.error(
-                    "[NoteUpdate] AI 요약 재생성 실패: note_id=%s, error=%s",
-                    updated_note.id,
-                    e,
-                    exc_info=True,
-                )
+        # ----------------------------------------------------------------------
+        # ❌ Gemini 요약 재생성 기능 비활성화
+        # if "content" in serializer.validated_data:
+        #     try:
+        #         StudyNoteAIService.summarize(updated_note)
+        #     except Exception as e:
+        #         logger.error("[NoteUpdate] AI 요약 재생성 실패: note_id=%s, error=%s", updated_note.id, e, exc_info=True)
+        # ----------------------------------------------------------------------
+
         return self.success("노트가 성공적으로 수정되었습니다.", StudyNoteDetailSerializer(updated_note).data)
 
     @extend_schema(tags=["StudyGroupNote"], summary="스터디 노트 삭제 API")


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: Recruitments API 명세서 불일치 수정 및 전체 리팩토링

## 📄 상세 내용
- REQ-RECM-001~009 전체 명세서 기준으로 API 동작 수정
- estimated_fee optional 처리 및 값 없을 시 자동 계산 적용
- attachments 필드 누락 문제 해결 (Serializer + View 반영)
- tags 값 미전달 시 "undefined" 저장되는 문제 해결 (_clean_tags() 개선)
- 공고 수정 시(PATCH) 모든 필드 optional 처리 (RecruitmentUpdateSerializer 적용)
- presigned URL 발급 API 추가 (/api/v1/recruitments/presigned-url)
- Swagger(Spectacular) 파라미터 명세서와 일치하도록 문서 전체 정리
- View 분기 로직 정리 (List / Create / Detail / Update / Delete)
- UUID 기반 study_group 매핑 수정 (명세서 기준)
- 테스트 코드 전체 수정 및 전체 테스트 통과 (66 passed)

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- 기존 코드와 명세서 차이가 꽤 심해 전체 구조 리팩토링 진행했습니다.
- FE 3팀에서 요청한 모든 API 불일치 사항 검증 완료.
- 실제 배포 시 주의: presigned-url은 현재 mock 응답이며 S3 연동 후 실제 업로드용 URL 반환 필요.

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
