### PR TITLE
Fix : validate_file_str_extension 추가

### DIFF
--- a/apps/core/utils/s3_uploader.py
+++ b/apps/core/utils/s3_uploader.py
@@ -77,6 +77,17 @@ class S3Uploader:
         raise ValidationError("허용된 확장자만 등록 가능합니다.")
 
     @classmethod
+    def validate_file_str_extension(cls, file_name: str) -> None:
+        """
+        파일 확장자 검증 (str 전용)
+        """
+        ext = file_name.rsplit(".", 1)[-1].lower()
+        if ext in ALLOWED_IMAGE_EXTENSIONS or ext in ALLOWED_ATTACHMENT_EXTENSIONS:
+            return
+
+        raise ValidationError("허용된 확장자만 등록 가능합니다.")
+
+    @classmethod
     def validate_file_content_type(cls, content_type: Optional[str]) -> None:
         """
         파일 확장자 검증

--- a/apps/studies/views/s3_presign.py
+++ b/apps/studies/views/s3_presign.py
@@ -95,7 +95,7 @@ class StudyNoteS3PresignedView(APIView):
 
             S3Uploader.validate_file_content_type(content_type)
             S3Uploader.validate_file_mime(ext, content_type)
-            S3Uploader.validate_file_extension(file_name)
+            S3Uploader.validate_file_str_extension(file_name)
 
             prefix = NOTE_IMAGE_PREFIX if content_type.startswith("image/") else NOTE_FILE_PREFIX
 


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: UploadedFile 타입을 유지하며 str 타입용 벨리데이트 추가

## 📄 상세 내용
- [ ] presign url 생성 중 str 타입으로 검증하게 수정해야해서 user service에서 UploadeFile 타입검증을 사용하고있어 유지하며 새로 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
