### PR TITLE
[Fix/recruitment_presigned_url_api] 잘못된 Validation 메서드 호출 정정, Serializer 구조 단순화, 알림 목록 조회 api에 is_read 쿼리파라미터 필터링 기능 추가

### DIFF
--- a/apps/notifications/views/views.py
+++ b/apps/notifications/views/views.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Count, Q, QuerySet
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import generics, permissions
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.request import Request
@@ -19,6 +21,23 @@ class NotificationListAPIView(generics.ListAPIView[Notification]):
     # 인증된 사용자만 접근 가능하게 설정 (permissions.py)
     permission_classes = [permissions.IsAuthenticated]
     pagination_class = LimitOffsetPagination
+
+    @extend_schema(
+        tags=["Notifications"],
+        summary="알림 목록 조회 API",
+        responses={200: NotificationSerializer(many=True)},
+        parameters=[
+            OpenApiParameter(
+                name="is_read",
+                type=OpenApiTypes.BOOL,
+                required=False,
+                location="query",
+                description="읽음 여부를 필터링하여 목록을 조회할 수 있는 쿼리 파라미터입니다. 미적용 시 모든 알림이 조회됩니다.",
+            )
+        ],
+    )
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        return self.list(request, *args, **kwargs)
 
     def get_queryset(self) -> QuerySet[Notification]:
         # 요청을 보낸 사용자만의 알림을 조회하도록 쿼리셋을 반환

--- a/apps/recruitments/views/s3_presign.py
+++ b/apps/recruitments/views/s3_presign.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from drf_spectacular.utils import extend_schema
-from rest_framework import status
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -22,36 +22,52 @@ class RecruitmentS3PresignedView(APIView):
 
     @extend_schema(
         tags=["Recruitments"],
-        request=PresignedRequestSerializer,
+        request=PresignedRequestSerializer(many=True),
         responses={
-            200: PresignedRequestSerializer,
+            200: inline_serializer(
+                name="PresignedRequestResponse",
+                fields={
+                    "status": serializers.IntegerField(),
+                    "message": serializers.CharField(),
+                    "data": serializers.ListField(
+                        child=inline_serializer(
+                            name="PresignedDataSerializer",
+                            fields={
+                                "file_name": serializers.CharField(),
+                                "key": serializers.CharField(),
+                                "url": serializers.URLField(),
+                                "fields": serializers.DictField(),
+                                "file_url": serializers.URLField(),
+                                "expires_in": serializers.IntegerField(),
+                            },
+                        )
+                    ),
+                },
+            ),
         },
     )
     def post(self, request: Request, *args: object, **kwargs: object) -> Response:
         serializer = PresignedRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        files = serializer.validated_data["files"]
+        file_data = serializer.validated_data
 
         presigned_urls: list[dict[str, Any]] = []
 
-        for f in files:
+        for f in file_data:
             file_name = f["file_name"]
             content_type = f["content_type"]
-            file_size = f["file_size"]
 
-            S3Uploader.validate_file_size(file_size)
-            S3Uploader.validate_file_name(file_name)
+            S3Uploader.validate_file_obj_name(file_name)
 
             ext = file_name.rsplit(".", 1)[-1].lower()
-
             S3Uploader.validate_file_content_type(content_type)
             S3Uploader.validate_file_mime(ext, content_type)
-            S3Uploader.validate_file_extension(file_name)
+            S3Uploader.validate_file_str_extension(file_name)
 
             prefix = RECRUIT_IMAGE_PREFIX if content_type.startswith("image/") else RECRUIT_FILE_PREFIX
 
-            presigned_urls = S3Uploader.generate_presigned_urls(prefix, files)
+            presigned_urls = S3Uploader.generate_presigned_urls(prefix, file_data)
 
         return Response(
             {

--- a/apps/studies/serializers/s3_presign.py
+++ b/apps/studies/serializers/s3_presign.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any
 
 from rest_framework import serializers
-
-
-class PresignedFileSerializer(serializers.Serializer[Any]):
-    file_name = serializers.CharField()
-    content_type = serializers.CharField()
-    file_size = serializers.IntegerField()
 
 
 class PresignedRequestSerializer(serializers.Serializer[Any]):
@@ -16,25 +10,6 @@ class PresignedRequestSerializer(serializers.Serializer[Any]):
     Presigned URL 발급 요청 검증용 Serializer
     """
 
-    files = PresignedFileSerializer(many=True)
-
-    def validate_files(self, value: List[dict[str, Any]]) -> List[Dict[str, Any]]:
-        if not value:
-            raise serializers.ValidationError("최소 1개 이상의 파일을 업로드해주세요.")
-
-        for f in value:
-            # 필드 존재 여부
-            required_fields = ("file_name", "content_type", "file_size")
-            for field in required_fields:
-                if field not in f:
-                    raise serializers.ValidationError(f"{field}는 필수입니다.")
-            # file_name 검증
-            if not isinstance(f["file_name"], str) or not f["file_name"].strip():
-                raise serializers.ValidationError("file_name은 비어 있지 않은 문자열이어야 합니다.")
-            # content_type 검증
-            if not isinstance(f["content_type"], str) or not f["content_type"].strip():
-                raise serializers.ValidationError("content_type은 비어 있지 않은 문자열이어야 합니다.")
-            # file_size 검증
-            if not isinstance(f["file_size"], int) or f["file_size"] <= 0:
-                raise serializers.ValidationError("file_size는 0보다 큰 정수여야 합니다.")
-        return value
+    file_name = serializers.CharField(required=True, allow_blank=False)
+    content_type = serializers.CharField(required=True, allow_blank=False)
+    file_size = serializers.IntegerField(required=True, allow_null=False, min_value=1, max_value=10 * 1024 * 1024)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 잘못된 Validation 메서드 호출 정정, Serializer 구조 단순화, 알림 목록 조회 api에 is_read 쿼리파라미터 필터링 기능 추가

## 📄 상세 내용
- [x] [🐛 fix: 잘못된 Validation 메서드 호출 정정, Serializer 구조 단순화](https://github.com/OZ-Coding-School/oz_externship_be_03/commit/a8c36963b68f8a819dac0aa28cb545b86f122d8b)
- [x] [✨ feat: is_read 쿼리파라미터 필터링 기능 추가](https://github.com/OZ-Coding-School/oz_externship_be_03/commit/2d425ae785d63f27bec5c3a72d37d832b9a103f7)

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
