### PR TITLE
Fix issue with parsing attachments and tags during post creation

### DIFF
--- a/apps/recruitments/serializers/recruitments.py
+++ b/apps/recruitments/serializers/recruitments.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Optional
+import json
+from typing import Optional, Union
 
 from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
@@ -186,26 +187,30 @@ class RecruitmentCreateUpdateSerializer(ModelSerializer[Recruitment]):
             raise serializers.ValidationError("예상 모집 인원은 1~10 사이여야 합니다.")
         return value
 
+    def validate_tags(self, value: str | list[str]) -> list[str]:
+        if isinstance(value, str):
+            try:
+                tags: list[str] = json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                raise serializers.ValidationError({"tags": "잘못된 JSON형식입니다."})
+        else:
+            tags = value
 
-# Create Response Serializer
+        if len(tags) > 5:
+            raise serializers.ValidationError({"tags": "태그는 최대 5개까지 등록 가능합니다."})
 
+        return tags
 
-class RecruitmentCreateSerializer(ModelSerializer[Recruitment]):
-    author = AuthorSerializer(read_only=True)
-    tags = TagSerializer(many=True, read_only=True)
+    def validate_attachments(self, value: Union[str, list[str]]) -> list[str]:
+        if isinstance(value, str):
+            try:
+                attachments: list[str] = json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                raise serializers.ValidationError({"attachments": "잘못된 JSON형식입니다."})
+        else:
+            attachments = value
 
-    class Meta:
-        model = Recruitment
-        fields = [
-            "id",
-            "uuid",
-            "title",
-            "content",
-            "estimated_fee",
-            "expected_headcount",
-            "close_at",
-            "study_group",
-            "author",
-            "tags",
-        ]
-        read_only_fields = ["id", "uuid", "author"]
+        if len(attachments) > 3:
+            raise serializers.ValidationError({"attachments": "파일첨부는 최대 3개까지 가능합니다."})
+
+        return attachments

--- a/apps/recruitments/tests/test_recruitments_api.py
+++ b/apps/recruitments/tests/test_recruitments_api.py
@@ -60,7 +60,7 @@ class RecruitmentAPITestCase(APITestCase):
             "tags": ["Django", "Python"],
         }
 
-        response = self.client.post(self.create_url, data, format="json")
+        response = self.client.post(self.create_url, data, format="multipart")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIn("title", response.data)
         self.assertEqual(response.data["title"], data["title"])

--- a/apps/recruitments/views/s3_presign.py
+++ b/apps/recruitments/views/s3_presign.py
@@ -47,7 +47,7 @@ class RecruitmentS3PresignedView(APIView):
         },
     )
     def post(self, request: Request, *args: object, **kwargs: object) -> Response:
-        serializer = PresignedRequestSerializer(data=request.data)
+        serializer = PresignedRequestSerializer(data=request.data, many=True)
         serializer.is_valid(raise_exception=True)
 
         file_data = serializer.validated_data


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: N/A
- 작업 요약: 공고 작성 시 attachments와 tags가 제대로 파싱되지 않는 문제를 해결했습니다.

## 📄 상세 내용
- [x] 공고 작성 로직에서 파싱 오류 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).